### PR TITLE
Make the production build minimized

### DIFF
--- a/webpack/webpack.common.js
+++ b/webpack/webpack.common.js
@@ -24,7 +24,6 @@ module.exports = {
         return true;
       },
     },
-    minimize: process.env.NODE_ENV == "production",
   },
   resolve: {
     extensions: [".js"],


### PR DESCRIPTION
The line being deleted requires an additional NODE_ENV environment variable which is not provided anywhere.
Without this line `npm run build-dev` and `npm run watch` build a non-minimized package with source maps and `npm run build` builds a minimized package.

Minimization decreases the content JS (content.js and vendor.js) file size from 718kB to 324kB.
