### PR TITLE
Add GitHub Action that creates a `latest` release on each commit

### DIFF
--- a/.github/workflows/latest-release.yml
+++ b/.github/workflows/latest-release.yml
@@ -1,0 +1,27 @@
+name: "latest-release"
+
+on:
+  push:
+    branches:
+      - development
+
+jobs:
+  latest-release:
+    name: "Latest Release"
+    runs-on: "ubuntu-latest"
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Use Node.js
+      uses: actions/setup-node@v2
+      with:
+        node-version: 16.x
+        cache: 'npm'
+    - run: npm ci
+    - run: npm run zip
+    - uses: "marvinpinto/action-automatic-releases@latest"
+      with:
+        repo_token: "${{ secrets.GITHUB_TOKEN }}"
+        prerelease: true
+        files: wikitree-browser-extension.zip
+        automatic_release_tag: "latest"


### PR DESCRIPTION
With this GitHub action it is no longer needed for commits like *[Update wikitree-browser-extension.zip](https://github.com/wikitree/wikitree-browser-extension/commit/b86bf44768274d50c193a239de0ee1f8ccc7a5cf)*. The zip file will appear automatically as a *latest* release in the GitHub repo.