### PR TITLE
Change the way features are registered

### DIFF
--- a/src/content.js
+++ b/src/content.js
@@ -1,20 +1,7 @@
 import { createTopMenu } from "./core/common";
-import "./features/agc/agc_content";
-import "./features/akaNameLinks/akaNameLinks";
-import "./features/appsMenu/appsMenu";
-import "./features/collapsibleDescendantsTree/collapsibleDescendantsTree";
-import "./features/darkMode/darkMode";
-import "./features/distanceAndRelationship/distanceAndRelationship";
-import "./features/draftList/draftList";
-import "./features/familyGroup/familyGroup";
-import "./features/familyTimeline/familyTimeline";
-import "./features/locationsHelper/locationsHelper";
-import "./features/printerfriendly/printerfriendly";
-import "./features/randomProfile/randomProfile";
-import "./features/sourcepreview/sourcepreview";
-import "./features/spacepreview/spacepreview";
-import "./features/wt+/contentEdit";
-import "./features/bioCheck/bioCheck";
+import { initializeFeatures } from "./core/features";
+import "./features/features";
 import "./core/editToolbar";
 
+initializeFeatures();
 createTopMenu();

--- a/src/core/features.js
+++ b/src/core/features.js
@@ -1,0 +1,33 @@
+// Categories
+export const GLOBAL = "Global";
+export const PROFILE = "Profile";
+export const EDITING = "Editing";
+export const STYLE = "Style";
+
+export const CATEGORIES = [GLOBAL, PROFILE, EDITING, STYLE];
+
+const features = [];
+
+/** Registers a new feature. */
+export function registerFeature(feature) {
+    features.push(feature);
+}
+
+/** Returns a list of all features. */
+export function getFeatures() {
+    return features;
+}
+
+/** Initializes all features that have been enabled in extension options. */
+export function initializeFeatures() {
+    for (const feature of features) {
+        chrome.storage.sync.get(feature.id, (result) => {
+            if (result[feature.id]) {
+                console.log('initializing', feature.id);
+                feature.init();
+            } else {
+                console.log('disabled', feature.id);
+            }
+        });        
+    }
+}

--- a/src/features/familyTimeline/familyTimeline.js
+++ b/src/features/familyTimeline/familyTimeline.js
@@ -1,28 +1,37 @@
 import * as $ from 'jquery';
 import 'jquery-ui/ui/widgets/draggable';
 import {createProfileSubmenuLink, extractRelatives, isOK} from '../../core/common';
+import {registerFeature, PROFILE} from '../../core/features';
 import './familyTimeline.css';
 
-chrome.storage.sync.get("familyTimeline", (result) => {
-  if (
-    result.familyTimeline &&
-    $("body.profile").length &&
-    window.location.href.match("Space:") == null
-  ) {
-    // Add a link to the short list of links below the tabs
-    const options = {
-      title: "Display a family timeline",
-      id: "familyTimeLineButton",
-      text: "Family Timeline",
-      url: "#n",
-    };
-    createProfileSubmenuLink(options);
-    $("#" + options.id).click(function (e) {
-      e.preventDefault();
-      timeline();
-    });
-  }
+registerFeature({
+  name: "Family Timeline",
+  id: "familyTimeline",
+  description:
+    "Displays a family timeline. A button is added to the profile submenu.",
+  category: PROFILE,
+  init,
 });
+
+function init() {
+  if (!$("body.profile").length ||
+      window.location.href.match("Space:") !== null) {
+    return;
+  }
+
+  // Add a link to the short list of links below the tabs
+  const options = {
+    title: "Display a family timeline",
+    id: "familyTimeLineButton",
+    text: "Family Timeline",
+    url: "#n",
+  };
+  createProfileSubmenuLink(options);
+  $("#" + options.id).click(function (e) {
+    e.preventDefault();
+    timeline();
+  });
+}
 
 async function getRelatives(id, fields = "*") {
   try {

--- a/src/features/features.js
+++ b/src/features/features.js
@@ -1,0 +1,16 @@
+import "./agc/agc_content";
+import "./akaNameLinks/akaNameLinks";
+import "./appsMenu/appsMenu";
+import "./collapsibleDescendantsTree/collapsibleDescendantsTree";
+import "./darkMode/darkMode";
+import "./distanceAndRelationship/distanceAndRelationship";
+import "./draftList/draftList";
+import "./familyGroup/familyGroup";
+import "./familyTimeline/familyTimeline";
+import "./locationsHelper/locationsHelper";
+import "./printerfriendly/printerfriendly";
+import "./randomProfile/randomProfile";
+import "./sourcepreview/sourcepreview";
+import "./spacepreview/spacepreview";
+import "./wt+/contentEdit";
+import "./bioCheck/bioCheck";

--- a/src/features/printerfriendly/printerfriendly.js
+++ b/src/features/printerfriendly/printerfriendly.js
@@ -1,20 +1,27 @@
 import $ from 'jquery';
 import {createTopMenuItem} from '../../core/common';
+import {registerFeature, GLOBAL} from '../../core/features';
 
-chrome.storage.sync.get('printerFriendly', (result) => {
-	if (result.printerFriendly) {
-		// create a top menu item
-		createTopMenuItem({
-			title: 'Changes the format to a printer-friendly one.',
-			name: 'Printer Friendly Bio',
-			id: 'wte-tm-printer-friendly'
-		});
-
-		$(`#wte-tm-printer-friendly`).on('click', () => {
-			printBio();
-		});
-	}
+registerFeature({
+    name: "Printer Friendly Bio",
+    id: "printerFriendly",
+    description: "Change the page to a printer-friendly one.",
+    category: GLOBAL,
+	init,
 });
+
+function init() {
+	// create a top menu item
+	createTopMenuItem({
+		title: 'Changes the format to a printer-friendly one.',
+		name: 'Printer Friendly Bio',
+		id: 'wte-tm-printer-friendly'
+	});
+
+	$(`#wte-tm-printer-friendly`).on('click', () => {
+		printBio();
+	});
+}
 
 // modified code from Steven's WikiTree Toolkit
 function printBio() {

--- a/src/options.js
+++ b/src/options.js
@@ -1,13 +1,9 @@
 import $ from 'jquery';
+import { CATEGORIES, getFeatures } from './core/features';
+import './features/features';
 
 // an array of information about features
-const features = [
-  {
-    name: "Printer Friendly Bio",
-    id: "printerFriendly",
-    description: "Change the page to a printer-friendly one.",
-    category: "Global",
-  },
+const features = getFeatures().concat([
   {
     name: "Source Previews",
     id: "sPreviews",
@@ -43,13 +39,6 @@ const features = [
     id: "akaNameLinks",
     description:
       'Adds surname page links to the "aka" names on the profile page.',
-    category: "Profile",
-  },
-  {
-    name: "Family Timeline",
-    id: "familyTimeline",
-    description:
-      "Displays a family timeline. A button is added to the profile submenu.",
     category: "Profile",
   },
   {
@@ -106,10 +95,7 @@ const features = [
     description: 'Check biography style and sources.',
     category: 'Editing',
   },
-];
-
-// Categories
-const categories = ["Global", "Profile", "Editing", "Style"];
+]);
 
 // saves options to chrome.storage
 function save_options() {
@@ -142,7 +128,7 @@ features.sort(function (a, b) {
 });
 
 // add each feature to the options page
-categories.forEach(function (category) {
+CATEGORIES.forEach(function (category) {
   $("#features").append(`<h2 data-category="${category}">${category} 
   <div class="feature-toggle">
   <label class="switch">


### PR DESCRIPTION
When adding a new feature:
- `src/options.js` file no longer needs to be modified
- feature's `name`, `id`, `description` and `category` are now defined in the feature source file, i.e. together with the feature
- feature code no longer has to call `chrome.storage.sync`

This PR is a suggestion with changes to `familyTimeline` and `printerFriendly` as examples. If everyone is OK with this change, I'll update other features and the documentation.
