### PR TITLE
Add pins to Category Finder, linking to category pages

### DIFF
--- a/src/content.js
+++ b/src/content.js
@@ -15,6 +15,7 @@ import "./features/sourcepreview/sourcepreview";
 import "./features/spacepreview/spacepreview";
 import "./features/wt+/contentEdit";
 import "./features/bioCheck/bioCheck";
+import "./features/categoryFinderPins/categoryFinderPins";
 import "./core/editToolbar";
 
 createTopMenu();

--- a/src/features/categoryFinderPins/categoryFinderPins.js
+++ b/src/features/categoryFinderPins/categoryFinderPins.js
@@ -1,0 +1,33 @@
+import $ from "jquery";
+
+async function addCategoryLinksToDropdown() {
+  $("#addCategoryInput").keyup(function () {
+    setTimeout(function () {
+      $(".autocomplete-suggestions:visible .autocomplete-suggestion").each(
+        function () {
+          const term = $(this).text();
+          const pin = $(
+            "<span class='autocomplete-suggestion-maplink'><a target='_new' href='https://www.wikitree.com/wiki/Category:" +
+              term +
+              "'><img src='/images/icons/map.gif'></a></span>"
+          );
+          if ($(this).prev("span").length == 0) {
+            pin.insertBefore($(this));
+          }
+        }
+      );
+    }, 1000);
+  });
+}
+
+chrome.storage.sync.get("categoryFinderPins", (result) => {
+  if (
+    result.categoryFinderPins &&
+    $("body.page-Special_EditPerson").length &&
+    $("body.BEE").length == 0
+  ) {
+    setTimeout(function () {
+      addCategoryLinksToDropdown();
+    }, 1000);
+  }
+});

--- a/src/options.js
+++ b/src/options.js
@@ -66,6 +66,13 @@ const features = [
     category: "Global",
   },
   {
+    name: "Distance and Relationship",
+    id: "distanceAndRelationship",
+    description:
+      "Adds the distance (degrees) between you and the profile person and any relationship between you.",
+    category: "Profile",
+  },
+  {
     name: "Locations Helper",
     id: "locationsHelper",
     description:
@@ -73,13 +80,7 @@ const features = [
       " based on family members' locations, and demoting likely wrong locations, based on the dates.",
     category: "Editing",
   },
-  {
-    name: "Distance and Relationship",
-    id: "distanceAndRelationship",
-    description:
-      "Adds the distance (degrees) between you and the profile person and any relationship between you.",
-    category: "Profile",
-  },
+
   {
     name: "Dark Mode",
     id: "darkMode",
@@ -106,10 +107,23 @@ const features = [
     description: "Check biography style and sources.",
     category: "Editing",
   },
+  {
+    name: "Category Finder Pins",
+    id: "categoryFinderPins",
+    description:
+      "Adds pins to Category Finder results (on the edit page), similar to the pins in the location dropdown.  These pins link to the category page for you to check that you have the right category.",
+    category: "Editing",
+  },
 ];
 
 // Categories
 const categories = ["Global", "Profile", "Editing", "Style"];
+// If a new feature is added with a new category, add the category to the list
+features.forEach(function (feature) {
+  if (!categories.includes(feature.category)) {
+    categories.push(feature.category);
+  }
+});
 
 // saves options to chrome.storage
 function save_options() {


### PR DESCRIPTION
On the locations dropdown, there are map pins.  This looks the same, but the pins go to category pages.