### PR TITLE
Sort badges

### DIFF
--- a/src/core/features.js
+++ b/src/core/features.js
@@ -3,31 +3,32 @@ export const GLOBAL = "Global";
 export const PROFILE = "Profile";
 export const EDITING = "Editing";
 export const STYLE = "Style";
+export const OTHER = "Other";
 
-export const CATEGORIES = [GLOBAL, PROFILE, EDITING, STYLE];
+export const CATEGORIES = [GLOBAL, PROFILE, EDITING, STYLE, OTHER];
 
 const features = [];
 
 /** Registers a new feature. */
 export function registerFeature(feature) {
-    features.push(feature);
+  features.push(feature);
 }
 
 /** Returns a list of all features. */
 export function getFeatures() {
-    return features;
+  return features;
 }
 
 /** Initializes all features that have been enabled in extension options. */
 export function initializeFeatures() {
-    for (const feature of features) {
-        chrome.storage.sync.get(feature.id, (result) => {
-            if (result[feature.id]) {
-                console.log('initializing', feature.id);
-                feature.init();
-            } else {
-                console.log('disabled', feature.id);
-            }
-        });        
-    }
+  for (const feature of features) {
+    chrome.storage.sync.get(feature.id, (result) => {
+      if (result[feature.id]) {
+        console.log("initializing", feature.id);
+        feature.init();
+      } else {
+        console.log("disabled", feature.id);
+      }
+    });
+  }
 }

--- a/src/features/features.js
+++ b/src/features/features.js
@@ -15,3 +15,4 @@ import "./spacepreview/spacepreview";
 import "./wt+/contentEdit";
 import "./bioCheck/bioCheck";
 import "./categoryFinderPins/categoryFinderPins";
+import "./sortBadges/sortBadges";

--- a/src/features/sortBadges/sortBadges.css
+++ b/src/features/sortBadges/sortBadges.css
@@ -1,0 +1,6 @@
+#clubBadgeButtons {
+  display: block;
+}
+#clubBadgeButtons button {
+  margin-top: 0.2em;
+}

--- a/src/features/sortBadges/sortBadges.js
+++ b/src/features/sortBadges/sortBadges.js
@@ -1,13 +1,13 @@
 import * as $ from "jquery";
-import { registerFeature, PROFILE } from "../../core/features";
+import { registerFeature, OTHER } from "../../core/features";
 import "./sortBadges.css";
 import Cookies from "js-cookie";
 
 registerFeature({
   name: "Sort Badges",
   id: "sortBadges",
-  description: "Move or hide your Club 100/1000 badges.",
-  category: PROFILE,
+  description: "Buttons to move or hide your Club 100/1000 badges.",
+  category: OTHER,
   init,
 });
 
@@ -50,7 +50,7 @@ function init() {
       .parent()
       .after(
         $(
-          '<span class="SMALL" style="background: none;" id="hideClubBadgesLink">[<a href="/index.php?title=Special:Badges&amp;u=19076274&action=hideClubBadges">hide Club 100/1000 badges</a>] </span><span class="SMALL" style="background: none;"  id="moveClubBadgesDownLink">[<a href="/index.php?title=Special:Badges&amp;u=19076274&action=moveClubBadgesDown">move Club 100/1000 badges down</a>]</span>'
+          '<span class="SMALL" style="background: none;" id="hideClubBadgesLink">[<a href="/index.php?title=Special:Badges&amp;u=19076274&action=hideClubBadges">hide Club badges</a>] </span><span class="SMALL" style="background: none;"  id="moveClubBadgesDownLink">[<a href="/index.php?title=Special:Badges&amp;u=19076274&action=moveClubBadgesDown">move Club badges down</a>]</span>'
         )
       );
   }
@@ -62,9 +62,7 @@ function saveBadgeChanges() {
 
 function hideClubBadges() {
   const clubBadgeLinks = $("a[href$='club100'],a[href$='club1000']");
-  console.log(clubBadgeLinks);
   clubBadgeLinks.each(function () {
-    console.log($(this).text());
     $(this).closest("li").find("input[name^='hide']").prop("checked", "true");
   });
   saveBadgeChanges();
@@ -72,7 +70,6 @@ function hideClubBadges() {
 
 function moveClubBadgesDown() {
   const clubBadgeLinks = $("a[href$='club100'],a[href$='club1000']");
-  console.log(clubBadgeLinks);
   clubBadgeLinks.each(function () {
     $(this).closest("li").appendTo($(this).closest("ul"));
   });

--- a/src/features/sortBadges/sortBadges.js
+++ b/src/features/sortBadges/sortBadges.js
@@ -1,0 +1,85 @@
+import * as $ from "jquery";
+import { registerFeature, PROFILE } from "../../core/features";
+import "./sortBadges.css";
+import Cookies from "js-cookie";
+
+registerFeature({
+  name: "Sort Badges",
+  id: "sortBadges",
+  description: "Move or hide your Club 100/1000 badges.",
+  category: PROFILE,
+  init,
+});
+
+function init() {
+  if ($("body.page-Special_Badges").length) {
+    $("div.sixteen.columns p")
+      .eq(0)
+      .append(
+        $(
+          "<menu id='clubBadgeButtons'><button class='small' id='hideClubBadges'>Hide Club Badges</button><button id='moveClubBadgesDown' class='small'>Move Club Badges Down</button></menu>"
+        )
+      );
+    $("#hideClubBadges").on("click", (e) => {
+      e.preventDefault();
+      hideClubBadges();
+    });
+    $("#moveClubBadgesDown").on("click", (e) => {
+      e.preventDefault();
+      moveClubBadgesDown();
+    });
+    const queryString = window.location.search;
+    const urlParams = new URLSearchParams(queryString);
+    if (localStorage.savedBadges) {
+      localStorage.removeItem("savedBadges");
+      window.location = $("a.pureCssMenui0 span.person").parent().attr("href");
+    }
+    if (urlParams.get("action")) {
+      localStorage.setItem("savedBadges", 1);
+      $("#" + urlParams.get("action")).trigger("click");
+      localStorage.removeItem("sortBadges");
+    }
+  }
+  if (
+    $("body.profile").length &&
+    window.location.href.match("Space:") == null &&
+    $("a.pureCssMenui0 span.person").text() ==
+      Cookies.get("wikitree_wtb_UserName")
+  ) {
+    $("a:contains('view/edit')")
+      .parent()
+      .after(
+        $(
+          '<span class="SMALL" style="background: none;" id="hideClubBadgesLink">[<a href="/index.php?title=Special:Badges&amp;u=19076274&action=hideClubBadges">hide Club 100/1000 badges</a>] </span><span class="SMALL" style="background: none;"  id="moveClubBadgesDownLink">[<a href="/index.php?title=Special:Badges&amp;u=19076274&action=moveClubBadgesDown">move Club 100/1000 badges down</a>]</span>'
+        )
+      );
+  }
+}
+
+function saveBadgeChanges() {
+  $("input[value='Save Display Changes']").trigger("click");
+}
+
+function hideClubBadges() {
+  const clubBadgeLinks = $("a[href$='club100'],a[href$='club1000']");
+  console.log(clubBadgeLinks);
+  clubBadgeLinks.each(function () {
+    console.log($(this).text());
+    $(this).closest("li").find("input[name^='hide']").prop("checked", "true");
+  });
+  saveBadgeChanges();
+}
+
+function moveClubBadgesDown() {
+  const clubBadgeLinks = $("a[href$='club100'],a[href$='club1000']");
+  console.log(clubBadgeLinks);
+  clubBadgeLinks.each(function () {
+    $(this).closest("li").appendTo($(this).closest("ul"));
+  });
+  const idArray = [];
+  $("#list_items li").each(function () {
+    idArray.push($(this).attr("id"));
+  });
+  $("#new_order").val(idArray.join(","));
+  saveBadgeChanges();
+}

--- a/src/options.js
+++ b/src/options.js
@@ -1,6 +1,6 @@
-import $ from 'jquery';
-import { CATEGORIES, getFeatures } from './core/features';
-import './features/features';
+import $ from "jquery";
+import { CATEGORIES, getFeatures } from "./core/features";
+import "./features/features";
 
 // an array of information about features
 const features = getFeatures().concat([
@@ -102,6 +102,12 @@ const features = getFeatures().concat([
     description:
       "Adds pins to Category Finder results (on the edit page), similar to the pins in the location dropdown.  These pins link to the category page for you to check that you have the right category.",
     category: "Editing",
+  },
+  {
+    name: "Sort Badges",
+    id: "sortBadges",
+    description: "Move or hide your Club 100/1000 badges.",
+    category: "Profile",
   },
 ]);
 

--- a/src/options.js
+++ b/src/options.js
@@ -103,12 +103,6 @@ const features = getFeatures().concat([
       "Adds pins to Category Finder results (on the edit page), similar to the pins in the location dropdown.  These pins link to the category page for you to check that you have the right category.",
     category: "Editing",
   },
-  {
-    name: "Sort Badges",
-    id: "sortBadges",
-    description: "Move or hide your Club 100/1000 badges.",
-    category: "Profile",
-  },
 ]);
 
 // saves options to chrome.storage


### PR DESCRIPTION
This is to hide or move the club badges down (which probably do the same job).  I think this is working OK, but please take a look.  It puts two links on the member's profile page (below the badges) and two buttons on the badges page.  The links on the profile page go to the badges page, click the buttons to run the functions, and then return the user to the profile page.  Let me know if you see anything strange.

I've added this as 'Other' on the options page.