### PR TITLE
Fix incorrect feature id in test (was "darkMode" should be "genderPredictor")

### DIFF
--- a/src/features/genderPredictor/genderPredictor.js
+++ b/src/features/genderPredictor/genderPredictor.js
@@ -7,7 +7,7 @@ import {
 
 import "./genderPredictor.css";
 
-checkIfFeatureEnabled("darkMode").then((result) => {
+checkIfFeatureEnabled("genderPredictor").then((result) => {
   if (result) {
     predictGender();
   }

--- a/src/features/genderPredictor/gender_predictor_options.js
+++ b/src/features/genderPredictor/gender_predictor_options.js
@@ -3,12 +3,12 @@ import {
   OptionType,
 } from "../../core/options/options_registry.js";
 
-const predictGenderFeature = {
+const genderPredictorFeature = {
   name: "Gender Predictor",
-  id: "genderpredictor",
+  id: "genderPredictor",
   description:
     "Sets the gender on a new profile page based on the name and the gender frequency of it in the WikiTree database.",
   category: "Editing",
 };
 
-registerFeature(predictGenderFeature);
+registerFeature(genderPredictorFeature);


### PR DESCRIPTION
After I merged Ian's PR I synced it and tested it. I noticed that it was testing for darkMode being enabled rather than featurePredictor. So I fixed that.

As part of that change I made the feature ID more consistent with the other ones.