### PR TITLE
Update edit toolbar to use checkIfFeatureEnabled

### DIFF
--- a/src/core/editToolbar.js
+++ b/src/core/editToolbar.js
@@ -4,7 +4,7 @@ import editToolbarProfileOptions from "./editToolbarProfileOptions";
 import editToolbarTemplateOptions from "./editToolbarTemplateOptions";
 import editToolbarSpaceOptions from "./editToolbarSpaceOptions";
 import "./editToolbar.css";
-import { checkIfFeatureEnabled } from "../options/options_storage"
+import { checkIfFeatureEnabled } from "./options/options_storage"
 
 let editToolbarOptions = [];
 

--- a/src/core/editToolbar.js
+++ b/src/core/editToolbar.js
@@ -4,6 +4,7 @@ import editToolbarProfileOptions from "./editToolbarProfileOptions";
 import editToolbarTemplateOptions from "./editToolbarTemplateOptions";
 import editToolbarSpaceOptions from "./editToolbarSpaceOptions";
 import "./editToolbar.css";
+import { checkIfFeatureEnabled } from "../options/options_storage"
 
 let editToolbarOptions = [];
 
@@ -91,17 +92,24 @@ function editToolbarCreateHtml(items, featureEnabled, level) {
 }
 
 /* creates menu next to the toolbar  */
-function editToolbarCreate(options) {
+async function editToolbarCreate(options) {
   editToolbarOptions = options;
-  chrome.storage.sync.get(null, (featureEnabled) => {
-    var menuHTML = editToolbarCreateHtml(editToolbarOptions, featureEnabled, -1);
-    document
-      .getElementById("toolbar")
-      .insertAdjacentHTML("afterend", '<div id="editToolbarExt">' + menuHTML + "</div>");
-    document
-      .querySelectorAll("a.editToolbarClick")
-      .forEach((i) => i.addEventListener("click", (event) => editToolbarEvent(event)));
-  });
+
+  // check which of the features used by the toolbar are enabled
+  let featureEnabled = [];
+  for (let item of editToolbarOptions) {
+    if (await checkIfFeatureEnabled(item.featureId)) {
+      featureEnabled[item.featureId] = true;
+    }
+  }
+
+  var menuHTML = editToolbarCreateHtml(editToolbarOptions, featureEnabled, -1);
+  document
+    .getElementById("toolbar")
+    .insertAdjacentHTML("afterend", '<div id="editToolbarExt">' + menuHTML + "</div>");
+  document
+    .querySelectorAll("a.editToolbarClick")
+    .forEach((i) => i.addEventListener("click", (event) => editToolbarEvent(event)));
 }
 
 if (window.location.href.match(/\/index.php\?title=Special:EditPerson&.*/g)) {


### PR DESCRIPTION
This is the last place where `chrome.storage.sync.get` is still being used directly to check if a feature is enabled.