### PR TITLE
Implement a default enabled state for features

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -49,6 +49,7 @@ registerFeature({
   id: "myFeature",
   description: "This feature does stuff.",
   category: "Global",
+  defaultValue: true,
 });
 ```
 
@@ -63,6 +64,7 @@ const myExampleFeature = {
   id: "myFeature",
   description: "This feature does stuff.",
   category: "Global",
+  defaultValue: true,
   options: [
     {
       id: "myFirstOption",

--- a/src/core/editToolbar.js
+++ b/src/core/editToolbar.js
@@ -4,7 +4,7 @@ import editToolbarProfileOptions from "./editToolbarProfileOptions";
 import editToolbarTemplateOptions from "./editToolbarTemplateOptions";
 import editToolbarSpaceOptions from "./editToolbarSpaceOptions";
 import "./editToolbar.css";
-import { checkIfFeatureEnabled } from "./options/options_storage"
+import { getEnabledStateForAllFeatures } from "./options/options_storage"
 
 let editToolbarOptions = [];
 
@@ -95,15 +95,7 @@ function editToolbarCreateHtml(items, featureEnabled, level) {
 async function editToolbarCreate(options) {
   editToolbarOptions = options;
 
-  // check which of the features used by the toolbar are enabled
-  let featureEnabled = [];
-  for (let item of editToolbarOptions) {
-    if (item.featureid) {
-      if (await checkIfFeatureEnabled(item.featureid)) {
-        featureEnabled[item.featureid] = true;
-      }
-    }
-  }
+  const featureEnabled = await getEnabledStateForAllFeatures();
 
   var menuHTML = editToolbarCreateHtml(editToolbarOptions, featureEnabled, -1);
   document

--- a/src/core/editToolbar.js
+++ b/src/core/editToolbar.js
@@ -4,7 +4,7 @@ import editToolbarProfileOptions from "./editToolbarProfileOptions";
 import editToolbarTemplateOptions from "./editToolbarTemplateOptions";
 import editToolbarSpaceOptions from "./editToolbarSpaceOptions";
 import "./editToolbar.css";
-import { checkIfFeatureEnabled } from "../options/options_storage"
+import { checkIfFeatureEnabled } from "./options/options_storage"
 
 let editToolbarOptions = [];
 

--- a/src/core/editToolbar.js
+++ b/src/core/editToolbar.js
@@ -4,6 +4,7 @@ import editToolbarProfileOptions from "./editToolbarProfileOptions";
 import editToolbarTemplateOptions from "./editToolbarTemplateOptions";
 import editToolbarSpaceOptions from "./editToolbarSpaceOptions";
 import "./editToolbar.css";
+import { checkIfFeatureEnabled } from "../options/options_storage"
 
 let editToolbarOptions = [];
 
@@ -91,17 +92,24 @@ function editToolbarCreateHtml(items, featureEnabled, level) {
 }
 
 /* creates menu next to the toolbar  */
-function editToolbarCreate(options) {
+async function editToolbarCreate(options) {
   editToolbarOptions = options;
-  chrome.storage.sync.get(null, (featureEnabled) => {
-    var menuHTML = editToolbarCreateHtml(editToolbarOptions, featureEnabled, -1);
-    document
-      .getElementById("toolbar")
-      .insertAdjacentHTML("afterend", '<div id="editToolbarExt">' + menuHTML + "</div>");
-    document
-      .querySelectorAll("a.editToolbarClick")
-      .forEach((i) => i.addEventListener("click", (event) => editToolbarEvent(event)));
-  });
+
+  // check which of the features used by the toolbar are enabled
+  let featureEnabled = [];
+  for (let item of editToolbarOptions) {
+    if (await checkIfFeatureEnabled(item.featureId)) {
+      featureEnabled[item.featureId] = true;
+    }
+  }
+
+  var menuHTML = editToolbarCreateHtml(editToolbarOptions, featureEnabled, -1);
+  document
+    .getElementById("toolbar")
+    .insertAdjacentHTML("afterend", '<div id="editToolbarExt">' + menuHTML + "</div>");
+  document
+    .querySelectorAll("a.editToolbarClick")
+    .forEach((i) => i.addEventListener("click", (event) => editToolbarEvent(event)));
 }
 
 if (window.location.href.match(/\/index.php\?title=Special:EditPerson&.*/g)) {

--- a/src/core/options/options_registry.js
+++ b/src/core/options/options_registry.js
@@ -7,7 +7,6 @@ const features = [
 
 function registerFeature(featureData) {
   features.push(featureData);
-  console.log("registerFeature. featureId is:" + featureData.id);
 }
 
 function getFeatureData(featureId) {
@@ -16,9 +15,6 @@ function getFeatureData(featureId) {
       return feature;
     }
   }
-
-  console.log("getFeatureData failed for id: " + featureId + ". features is:");
-  console.log(features);
 }
 
 const OptionType = {

--- a/src/core/options/options_registry.js
+++ b/src/core/options/options_registry.js
@@ -7,6 +7,7 @@ const features = [
 
 function registerFeature(featureData) {
   features.push(featureData);
+  console.log("registerFeature. featureId is:" + featureData.id);
 }
 
 function getFeatureData(featureId) {
@@ -15,6 +16,9 @@ function getFeatureData(featureId) {
       return feature;
     }
   }
+
+  console.log("getFeatureData failed for id: " + featureId + ". features is:");
+  console.log(features);
 }
 
 const OptionType = {
@@ -68,4 +72,4 @@ function getDefaultOptionValuesForFeature(featureId, useTestDefaults = false) {
   return defaultValues;
 }
 
-export { registerFeature, features, getDefaultOptionValuesForFeature, OptionType };
+export { registerFeature, features, getDefaultOptionValuesForFeature, OptionType, getFeatureData };

--- a/src/core/options/options_storage.js
+++ b/src/core/options/options_storage.js
@@ -54,17 +54,13 @@ This function returns a Promise so it can be used in a couple of different ways:
 
 1. Using then:
 
-  checkIfFeatureEnabled("agc").then((result) => {
-    if (result) {
-      initAgc();
-    }
+  getEnabledStateForAllFeatures().then((featuresEnabled) => {
+    ...
   });
 
 2. Using await:
 
-  if (await checkIfFeatureEnabled("agc") {
-    initAgc();
-  });
+  const featuresEnabled = await getEnabledStateForAllFeatures();
 */
 
 async function getEnabledStateForAllFeatures() {

--- a/src/core/options/options_storage.js
+++ b/src/core/options/options_storage.js
@@ -1,4 +1,4 @@
-import { getDefaultOptionValuesForFeature } from "./options_registry"
+import { getDefaultOptionValuesForFeature, getFeatureData } from "./options_registry"
 
 /*
 This function returns a Promise so it can be used in a couple of different ways:
@@ -25,10 +25,22 @@ async function checkIfFeatureEnabled(featureId) {
         reject(new Error("No featureId provided"));
       }
 
+      console.log("checkIfFeatureEnabled calling getFeatureData with id: " + featureId);
+
+      const featureData = getFeatureData(featureId);
+      if (featureData) {
+        reject(new Error(`Invalid featureId: ${featureId}`));
+      }
+
       const itemKey = featureId;
       chrome.storage.sync.get(itemKey,
         function (items) {
           const result = items[itemKey];
+
+          if (result === undefined) {
+            // no saved value for enabled yet. Use default.
+            result = (featureData.defaultValue) ? true : false;
+          }
 
           resolve(result);
         }

--- a/src/features/agc/agc_options.js
+++ b/src/features/agc/agc_options.js
@@ -7,6 +7,7 @@ const agcFeature = {
   description:
     "Reformats a biography and updates data fields when the profile was created from a GEDCOM.",
   category: "Editing",
+  defaultValue: true,
   options: [
     {
       id: "bioMainText",

--- a/src/features/darkMode/darkMode_options.js
+++ b/src/features/darkMode/darkMode_options.js
@@ -8,6 +8,7 @@ import {
     id: "darkMode",
     description: "Make WikiTree dark.",
     category: "Style",
+    defaultValue: false,
     options: [
       {
         id: "mode",

--- a/src/features/genderPredictor/gender_predictor_options.js
+++ b/src/features/genderPredictor/gender_predictor_options.js
@@ -9,6 +9,7 @@ const genderPredictorFeature = {
   description:
     "Sets the gender on a new profile page based on the name and the gender frequency of it in the WikiTree database.",
   category: "Editing",
+  defaultValue: true,
 };
 
 registerFeature(genderPredictorFeature);

--- a/src/features/redir_ext_links/redir_ext_links_options.js
+++ b/src/features/redir_ext_links/redir_ext_links_options.js
@@ -5,6 +5,7 @@ const redirExtLinksFeature = {
   id: "redirExtLinks",
   description: "Updates links to external sites to point to user desired domains.",
   category: "Profile",
+  defaultValue: false,
   options: [
     {
       id: "ancestryOldLinks",

--- a/src/features/register_feature_options.js
+++ b/src/features/register_feature_options.js
@@ -20,6 +20,7 @@ registerFeature({
   id: "myMenu",
   description: "Add your own custom menu for easy access to your most commonly used links.",
   category: "Global",
+  defaultValue: false,
 });
 
 registerFeature({
@@ -27,6 +28,7 @@ registerFeature({
   id: "printerFriendly",
   description: "Change the page to a printer-friendly one.",
   category: "Global",
+  defaultValue: true,
 });
 
 registerFeature({
@@ -34,6 +36,7 @@ registerFeature({
   id: "sPreviews",
   description: "Enable source previews on inline references.",
   category: "Global",
+  defaultValue: false,
 });
 
 registerFeature({
@@ -41,6 +44,7 @@ registerFeature({
   id: "spacePreviews",
   description: "Enable previews of Space Pages on hover.",
   category: "Global",
+  defaultValue: false,
 });
 
 registerFeature({
@@ -48,6 +52,7 @@ registerFeature({
   id: "appsMenu",
   description: "Adds an apps submenu to the Find menu.",
   category: "Global",
+  defaultValue: true,
 });
 
 registerFeature({
@@ -55,6 +60,7 @@ registerFeature({
   id: "wtplus",
   description: "Adds multiple editing features.",
   category: "Editing",
+  defaultValue: true,
 });
 
 registerFeature({
@@ -62,6 +68,7 @@ registerFeature({
   id: "collapsibleDescendantsTree",
   description: "Makes the descendants tree on profile pages collapsible.",
   category: "Profile",
+  defaultValue: true,
 });
 
 registerFeature({
@@ -69,6 +76,7 @@ registerFeature({
   id: "akaNameLinks",
   description: 'Adds surname page links to the "aka" names on the profile page.',
   category: "Profile",
+  defaultValue: true,
 });
 
 registerFeature({
@@ -76,6 +84,7 @@ registerFeature({
   id: "familyTimeline",
   description: "Displays a family timeline. A button is added to the profile submenu.",
   category: "Profile",
+  defaultValue: true,
 });
 
 registerFeature({
@@ -83,6 +92,7 @@ registerFeature({
   id: "draftList",
   description: "Adds a button to the Find menu to show your uncommitted drafts.",
   category: "Global",
+  defaultValue: true,
 });
 
 registerFeature({
@@ -90,6 +100,7 @@ registerFeature({
   id: "randomProfile",
   description: "Adds a Random Profile link to the Find menu.",
   category: "Global",
+  defaultValue: true,
 });
 
 registerFeature({
@@ -97,6 +108,7 @@ registerFeature({
   id: "distanceAndRelationship",
   description: "Adds the distance (degrees) between you and the profile person and any relationship between you.",
   category: "Profile",
+  defaultValue: true,
 });
 
 registerFeature({
@@ -106,6 +118,7 @@ registerFeature({
     "Manipulates the suggested locations, highlighting likely correct locations," +
     " based on family members' locations, and demoting likely wrong locations, based on the dates.",
   category: "Editing",
+  defaultValue: true,
 });
 
 registerFeature({
@@ -113,6 +126,7 @@ registerFeature({
   id: "familyGroup",
   description: "Display dates and locations of all family members. A button is added to the profile submenu.",
   category: "Profile",
+  defaultValue: true,
 });
 
 registerFeature({
@@ -120,6 +134,7 @@ registerFeature({
   id: "bioCheck",
   description: "Check biography style and sources.",
   category: "Editing",
+  defaultValue: true,
 });
 
 registerFeature({
@@ -128,6 +143,7 @@ registerFeature({
   description:
     "Adds pins to Category Finder results (on the edit page), similar to the pins in the location dropdown.  These pins link to the category page for you to check that you have the right category.",
   category: "Editing",
+  defaultValue: true,
 });
 
 registerFeature({
@@ -135,6 +151,7 @@ registerFeature({
   id: "sortBadges",
   description: "Buttons to move or hide your Club 100/1000 badges.",
   category: "Other",
+  defaultValue: true,
 });
 
 registerFeature({
@@ -143,4 +160,5 @@ registerFeature({
   description:
     "When attaching a person by ID, you can see some details of the person and check that you've entered the correct ID.",
   category: "Editing",
+  defaultValue: true,
 });

--- a/src/options.js
+++ b/src/options.js
@@ -143,7 +143,11 @@ function saveFeatureOnOffOptions() {
 function restore_options() {
   chrome.storage.sync.get(null, (items) => {
     features.forEach((feature) => {
-      $(`#${feature.id} input`).prop("checked", items[`${feature.id}`]);
+      let featureEnabled = items[feature.id];
+      if (featureEnabled === undefined) {
+        featureEnabled = (feature.defaultValue) ? true : false;
+      }
+      $(`#${feature.id} input`).prop("checked", featureEnabled);
       restoreFeatureOptions(feature, items);
     });
   });


### PR DESCRIPTION
When a feature is registered it specifies a defaultValue which says whether it is enabled by default or not.

The options page takes those default values into account. So does `checkIfFeatureEnabled`.

As part of this change I switched `editToolbar.js` to use `options_storage` to check whether features are enabled. All other features are already doing that now.

I may not have correctly set the desired values for which features should be enabled by default but these are easily changed.

This completes the work for these two issues: https://github.com/wikitree/wikitree-browser-extension/issues/49 and https://github.com/wikitree/wikitree-browser-extension/issues/103