### PR TITLE
Fix timing issue that can cause AGC button to be on right

### DIFF
--- a/src/features/agc/agc_content.js
+++ b/src/features/agc/agc_content.js
@@ -22,7 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
 
-import { checkIfFeatureEnabled, getFeatureOptions } from "../../core/options/options_storage"
+import { checkIfFeatureEnabled, getFeatureOptions } from "../../core/options/options_storage";
 
 // file level variables
 var agcButton = undefined;
@@ -520,8 +520,8 @@ function initAgc() {
     agcButton.title = "Ancestry GEDCOM Cleanup";
     agcButton.style = "cursor: pointer;";
 
-    // This adds it on the left side of the toolbar, I would prefer the right but can't get that to happen
-    toolbar.appendChild(agcButton);
+    // This adds it on the left side of the toolbar
+    toolbar.insertBefore(agcButton, toolbar.firstChild);
 
     agcButton.addEventListener("click", onButtonClicked, false);
   }


### PR DESCRIPTION
Kay noticed that, for her, the AGC button was showing up on the right of the toolbar, it has always show up on the left before.

I think that was just a timing issues in that it was on the left if the extension content script appended it before the web page added the standard buttons.
