### PR TITLE
Fix timing bug in agc that cause button to be on right of toolbar

### DIFF
--- a/src/features/agc/agc_content.js
+++ b/src/features/agc/agc_content.js
@@ -520,8 +520,8 @@ function initAgc() {
     agcButton.title = "Ancestry GEDCOM Cleanup";
     agcButton.style = "cursor: pointer;";
 
-    // This adds it on the left side of the toolbar, I would prefer the right but can't get that to happen
-    toolbar.appendChild(agcButton);
+    // This adds it on the left side of the toolbar
+    toolbar.insertBefore(agcButton, toolbar.firstChild);
 
     agcButton.addEventListener("click", onButtonClicked, false);
   }


### PR DESCRIPTION
We want the button on  the left but current implementation is dodgy - only puts it on the left if the content script does it before the web page does.