### PR TITLE
Add categoryDisplay feature

### DIFF
--- a/src/content.js
+++ b/src/content.js
@@ -6,6 +6,7 @@ import "./features/agc/agc_content";
 import "./features/akaNameLinks/akaNameLinks";
 import "./features/appsMenu/appsMenu";
 import "./features/bioCheck/bioCheck";
+import "./features/categoryDisplay/categoryDisplay";
 import "./features/categoryFinderPins/categoryFinderPins";
 import "./features/clipboard_and_notes/clipboard_and_notes";
 import "./features/collapsibleDescendantsTree/collapsibleDescendantsTree";

--- a/src/features/categoryDisplay/categoryDisplay.js
+++ b/src/features/categoryDisplay/categoryDisplay.js
@@ -1,0 +1,16 @@
+import $ from 'jquery';
+import {pageProfile} from '../../core/common';
+import { checkIfFeatureEnabled } from "../../core/options/options_storage.js";
+
+function moveCategories(){
+    $("#categories").find('span[class="SMALL"]').remove();
+    $('div:contains("This page has been accessed")').next().attr('id','cousinLinks');
+    $("#cousinLinks").after($("#categories"));
+    $("#categories").css({"border":"none","padding":"5px","margin-top":"10px"});
+}
+
+checkIfFeatureEnabled("categoryDisplay").then((result) => {
+    if (result && pageProfile == true) { 
+        moveCategories();
+    }
+})

--- a/src/features/register_feature_options.js
+++ b/src/features/register_feature_options.js
@@ -41,6 +41,15 @@ registerFeature({
 });
 
 registerFeature({
+  name: "Category Display",
+  id: "categoryDisplay",
+  description:
+    "Changes the location of Categories to the top of the Bio.",
+  category: "Profile",
+  defaultValue: false,
+});
+
+registerFeature({
   name: "Category Finder Pins",
   id: "categoryFinderPins",
   description:


### PR DESCRIPTION
[Requested in G2G](https://www.wikitree.com/g2g/1490020/have-you-seen-the-wikitree-browser-extension?show=1490664#a1490664); from the old WikiTree Toolkit extension.

When enabled, this will move the category links to the top of profiles.