### PR TITLE
Add permissions to use WikiTree API in Firefox manifest

### DIFF
--- a/src/manifest/manifest-firefox.json
+++ b/src/manifest/manifest-firefox.json
@@ -7,7 +7,7 @@
 		"page": "options.html",
 		"open_in_tab": true
 	},
-	"permissions": [ "https://www.wikitree.com/*", "storage" ],
+	"permissions": [ "https://www.wikitree.com/*", "https://api.wikitree.com/*", "storage" ],
 	"content_scripts": [
 		{
 			"matches": [ "https://www.wikitree.com/*" ],


### PR DESCRIPTION
Solution found here: https://stackoverflow.com/questions/66853081/firefox-error-networkerror-when-attempting-to-fetch-resource-only-from-extensio