### PR TITLE
Sort theme people

### DIFF
--- a/src/content.js
+++ b/src/content.js
@@ -24,6 +24,7 @@ import "./features/printerfriendly/printerfriendly";
 import "./features/randomProfile/randomProfile";
 import "./features/redir_ext_links/redir_ext_links";
 import "./features/sortBadges/sortBadges";
+import "./features/sort_theme_people/sort_theme_people";
 import "./features/sourcepreview/sourcepreview";
 import "./features/spacepreview/spacepreview";
 import "./features/verifyID/verifyID";

--- a/src/features/distanceAndRelationship/distanceAndRelationship.js
+++ b/src/features/distanceAndRelationship/distanceAndRelationship.js
@@ -162,7 +162,7 @@ async function getConnectionFinderResult(id1, id2, relatives = 0) {
   }
 }
 
-async function getRelationshipFinderResult(id1, id2) {
+export async function getRelationshipFinderResult(id1, id2) {
   try {
     const result = await $.ajax({
       url: "https://www.wikitree.com/index.php",
@@ -421,7 +421,7 @@ function ancestorType(generation, gender) {
   return relType;
 }
 
-function ordinalWordToNumberAndSuffix(word) {
+export function ordinalWordToNumberAndSuffix(word) {
   const ordinalsArray = [
     ["first", "1st"],
     ["second", "2nd"],

--- a/src/features/familyTimeline/familyTimeline.js
+++ b/src/features/familyTimeline/familyTimeline.js
@@ -133,7 +133,7 @@ function getAge(birth, death) {
   return age;
 }
 
-function capitalizeFirstLetter(string) {
+export function capitalizeFirstLetter(string) {
   string = string.toLowerCase();
   const bits = string.split(" ");
   let out = "";

--- a/src/features/register_feature_options.js
+++ b/src/features/register_feature_options.js
@@ -149,6 +149,14 @@ registerFeature({
 });
 
 registerFeature({
+  name: "Sort Theme People",
+  id: "sortThemePeople",
+  description: "Adds a button to sort the 'Theme of the Week' people on profile pages.",
+  category: "Profile",
+  defaultValue: true,
+});
+
+registerFeature({
   name: "Source Previews",
   id: "sPreviews",
   description: "Enable source previews on inline references.",

--- a/src/features/register_feature_options.js
+++ b/src/features/register_feature_options.js
@@ -151,9 +151,10 @@ registerFeature({
 registerFeature({
   name: "Sort Theme People",
   id: "sortThemePeople",
-  description: "Adds a button to sort the 'Theme of the Week' people on profile pages.",
+  description:
+    "Replaces the Connection Finder (theme of the week) section on Profile pages with a table sorted by degree of closeness to the profile person.",
   category: "Profile",
-  defaultValue: true,
+  defaultValue: false,
 });
 
 registerFeature({

--- a/src/features/sort_theme_people/sort_theme_people.css
+++ b/src/features/sort_theme_people/sort_theme_people.css
@@ -2,11 +2,19 @@
   margin: auto;
 }
 #themeTable caption {
-  background: forestgreen;
+  background: #e1f0b4;
+  box-shadow: green 0px 2px 2px 0px;
   border-radius: 1em;
   font-weight: bold;
-  color: white;
+  font-size: 1.5em;
+  padding: 0.2em;
 }
 #themeTable td {
   padding: 0.2em;
+}
+#themeTableButton {
+  margin: 1em auto;
+  width: 10em;
+  display: block;
+  clear: both;
 }

--- a/src/features/sort_theme_people/sort_theme_people.css
+++ b/src/features/sort_theme_people/sort_theme_people.css
@@ -19,3 +19,6 @@
   display: block;
   clear: both;
 }
+h2.thisWeeksTheme {
+  display: none;
+}

--- a/src/features/sort_theme_people/sort_theme_people.css
+++ b/src/features/sort_theme_people/sort_theme_people.css
@@ -1,0 +1,12 @@
+#themeTable {
+  margin: auto;
+}
+#themeTable caption {
+  background: forestgreen;
+  border-radius: 1em;
+  font-weight: bold;
+  color: white;
+}
+#themeTable td {
+  padding: 0.2em;
+}

--- a/src/features/sort_theme_people/sort_theme_people.css
+++ b/src/features/sort_theme_people/sort_theme_people.css
@@ -6,8 +6,9 @@
   box-shadow: green 0px 2px 2px 0px;
   border-radius: 1em;
   font-weight: bold;
-  font-size: 1.5em;
+  font-size: 1.2em;
   padding: 0.2em;
+  margin-bottom: 0.7em;
 }
 #themeTable td {
   padding: 0.2em;

--- a/src/features/sort_theme_people/sort_theme_people.js
+++ b/src/features/sort_theme_people/sort_theme_people.js
@@ -1,0 +1,72 @@
+import $ from "jquery";
+import "./sort_theme_people.css";
+import {
+  getRelationshipFinderResult,
+  ordinalWordToNumberAndSuffix,
+} from "../distanceAndRelationship/distanceAndRelationship";
+import { checkIfFeatureEnabled, getFeatureOptions } from "../../core/options/options_storage";
+
+checkIfFeatureEnabled("sortThemePeople").then((result) => {
+  if (
+    result &&
+    $("body.profile").length &&
+    $(".sixteen p a:contains(degrees from),.sixteen div.box.rounded.row a:contains(degrees from)").length
+  ) {
+    themePeopleTable();
+  }
+});
+
+function themePeopleTable() {
+  const linksArray = [];
+  const themeLinks = $(".sixteen p a:contains(degrees from),.sixteen div.box.rounded.row a:contains(degrees from)");
+  themeLinks.each(function () {
+    let aThemePerson = {};
+    aThemePerson.connectionURL = $(this).attr("href");
+    let urlParams = new URLSearchParams(aThemePerson.connectionURL);
+    aThemePerson.WTID = urlParams.get("person1Name");
+    let textSplit = $(this).text().split(" degrees from ");
+    aThemePerson.degrees = textSplit[0];
+    aThemePerson.name = textSplit[1];
+    linksArray.push(aThemePerson);
+  });
+  const profileName = $("h1 span[itemprop='name']").text();
+  const themeTable = $(`<table id='themeTable'>
+  <caption>Degrees from ${profileName}</caption>
+  <thead></thead>
+  <tbody></tbody>
+  </table>`);
+  themeLinks.parent().slideUp();
+  themeLinks.parent().after(themeTable);
+  linksArray.sort(function (a, b) {
+    return parseInt(a.degrees) > parseInt(b.degrees) ? 1 : -1;
+  });
+  linksArray.forEach(function (aPerson) {
+    let aRow = $(
+      `<tr><td><a href='/wiki/${aPerson.WTID}'>${aPerson.name}</a></td><td><a href='${aPerson.connectionURL}'>${aPerson.degrees} degrees</a></td></tr>`
+    );
+    themeTable.find("tbody").append(aRow);
+    const profileID = $("a.pureCssMenui0 span.person").text();
+    getRelationshipFinderResult(profileID, aPerson.WTID).then((data) => {
+      if (data) {
+        var out = "";
+        var aRelationship = true;
+        const commonAncestors = [];
+        let realOut = "";
+        let dummy = $("<html></html>");
+        dummy.append($(data.html));
+        if (dummy.find("h1").length) {
+          if (dummy.find("h1").eq(0).text() == "No Relationship Found") {
+            aRelationship = false;
+            console.log("No Relationship Found");
+          }
+        }
+        if (dummy.find("h2").length && aRelationship == true) {
+          let out = dummy.find("h2").eq(0).text().trim();
+          $("#themeTable a[href$='" + aPerson.WTID + "']")
+            .closest("tr")
+            .append($(`<td>${out}</td>`));
+        }
+      }
+    });
+  });
+}

--- a/src/features/sort_theme_people/sort_theme_people.js
+++ b/src/features/sort_theme_people/sort_theme_people.js
@@ -4,6 +4,8 @@ import {
   getRelationshipFinderResult,
   ordinalWordToNumberAndSuffix,
 } from "../distanceAndRelationship/distanceAndRelationship";
+import { capitalizeFirstLetter } from "../familyTimeline/familyTimeline";
+import { isOK } from "../../core/common.js";
 import { checkIfFeatureEnabled, getFeatureOptions } from "../../core/options/options_storage";
 
 checkIfFeatureEnabled("sortThemePeople").then((result) => {
@@ -12,61 +14,232 @@ checkIfFeatureEnabled("sortThemePeople").then((result) => {
     $("body.profile").length &&
     $(".sixteen p a:contains(degrees from),.sixteen div.box.rounded.row a:contains(degrees from)").length
   ) {
-    themePeopleTable();
+    if ($("h2.thisWeeksTheme").length == 0) {
+      connectionsBanner();
+    }
+    $(".sixteen p a:contains(degrees from),.sixteen div.box.rounded.row a:contains(degrees from)")
+      .closest("div")
+      .before($("<button id='themeTableButton' class='small button'>Theme list</button>"));
+    $("#themeTableButton").on("click", function (e) {
+      e.preventDefault();
+      themePeopleTable();
+    });
+    // themePeopleTable();
   }
 });
 
 function themePeopleTable() {
-  const linksArray = [];
-  const themeLinks = $(".sixteen p a:contains(degrees from),.sixteen div.box.rounded.row a:contains(degrees from)");
-  themeLinks.each(function () {
-    let aThemePerson = {};
-    aThemePerson.connectionURL = $(this).attr("href");
-    let urlParams = new URLSearchParams(aThemePerson.connectionURL);
-    aThemePerson.WTID = urlParams.get("person1Name");
-    let textSplit = $(this).text().split(" degrees from ");
-    aThemePerson.degrees = textSplit[0];
-    aThemePerson.name = textSplit[1];
-    linksArray.push(aThemePerson);
-  });
-  const profileName = $("h1 span[itemprop='name']").text();
-  const themeTable = $(`<table id='themeTable'>
-  <caption>Degrees from ${profileName}</caption>
+  if ($("#themeTable").length) {
+    $("#themeTable").toggle();
+    $("h2.thisWeeksTheme").toggle();
+    $("p.cfParagraph").toggle();
+    $(".sixteen a:contains(degrees from)").closest("div.box.rounded.row").toggle();
+  } else {
+    const linksArray = [];
+    const themeLinks = $(".sixteen p a:contains(degrees from),.sixteen div.box.rounded.row a:contains(degrees from)");
+    themeLinks.each(function () {
+      let aThemePerson = {};
+      aThemePerson.connectionURL = $(this).attr("href");
+      let urlParams = new URLSearchParams(aThemePerson.connectionURL);
+      aThemePerson.WTID = urlParams.get("person1Name");
+      let textSplit = $(this).text().split(" degrees from ");
+      aThemePerson.degrees = textSplit[0];
+      aThemePerson.name = textSplit[1];
+      linksArray.push(aThemePerson);
+    });
+
+    const profileName = $("h1 span[itemprop='name']").text();
+    const themeTable = $(`<table id='themeTable'>
+  <caption>Featured Connections</caption>
   <thead></thead>
   <tbody></tbody>
   </table>`);
-  themeLinks.parent().slideUp();
-  themeLinks.parent().after(themeTable);
-  linksArray.sort(function (a, b) {
-    return parseInt(a.degrees) > parseInt(b.degrees) ? 1 : -1;
-  });
-  linksArray.forEach(function (aPerson) {
-    let aRow = $(
-      `<tr><td><a href='/wiki/${aPerson.WTID}'>${aPerson.name}</a></td><td><a href='${aPerson.connectionURL}'>${aPerson.degrees} degrees</a></td></tr>`
-    );
-    themeTable.find("tbody").append(aRow);
-    const profileID = $("a.pureCssMenui0 span.person").text();
-    getRelationshipFinderResult(profileID, aPerson.WTID).then((data) => {
-      if (data) {
-        var out = "";
-        var aRelationship = true;
-        const commonAncestors = [];
-        let realOut = "";
-        let dummy = $("<html></html>");
-        dummy.append($(data.html));
-        if (dummy.find("h1").length) {
-          if (dummy.find("h1").eq(0).text() == "No Relationship Found") {
-            aRelationship = false;
-            console.log("No Relationship Found");
+    const themeTitle = $("h2.thisWeeksTheme");
+    themeTitle.hide();
+    themeTable.find("caption").html(themeTitle.text().replace(":", ":<br>"));
+
+    themeLinks.parent().slideUp();
+    themeLinks.parent().after(themeTable);
+    linksArray.sort(function (a, b) {
+      return parseInt(a.degrees) > parseInt(b.degrees) ? 1 : -1;
+    });
+    linksArray.forEach(function (aPerson) {
+      let aRow = $(
+        `<tr><td><a href='/wiki/${aPerson.WTID}'>${aPerson.name}</a></td><td><a href='${aPerson.connectionURL}'>${aPerson.degrees} degrees</a></td><td></td></tr>`
+      );
+      themeTable.find("tbody").append(aRow);
+      const profileID = $("a.pureCssMenui0 span.person").text();
+      getRelationshipFinderResult(profileID, aPerson.WTID).then((data) => {
+        if (data) {
+          var out = "";
+          var aRelationship = true;
+          const commonAncestors = [];
+          let realOut = "";
+          let dummy = $("<html></html>");
+          dummy.append($(data.html));
+          if (dummy.find("h1").length) {
+            if (dummy.find("h1").eq(0).text() == "No Relationship Found") {
+              aRelationship = false;
+              console.log("No Relationship Found");
+            }
+          }
+          if (dummy.find("h2").length && aRelationship == true) {
+            let out = dummy.find("h2").eq(0).text().trim();
+            $("#themeTable a[href$='" + aPerson.WTID + "']")
+              .closest("tr")
+              .find("td:last")
+              .append(
+                $(
+                  `<a href='https://www.wikitree.com/index.php?title=Special:Relationship&action=calculate&person1_name=${profileID}&person2_name=${aPerson.WTID}'>${out}</a>`
+                )
+              );
           }
         }
-        if (dummy.find("h2").length && aRelationship == true) {
-          let out = dummy.find("h2").eq(0).text().trim();
-          $("#themeTable a[href$='" + aPerson.WTID + "']")
-            .closest("tr")
-            .append($(`<td>${out}</td>`));
+      });
+    });
+  }
+}
+
+async function setConnectionsBanner() {
+  let theP = $("body.profile div.sixteen.columns p a[href*='Special:Connection']").closest("p");
+  if (theP.length) {
+    theP.addClass("cfParagraph");
+  } else {
+    theP = $("body.profile div.sixteen.columns div.box.rounded a[href*='Special:Connection']").closest("div");
+  }
+  const theDiv = theP.closest("div");
+  if (!window.noHeading && localStorage.cfTitle != "") {
+    let dTitle = "";
+    if (localStorage.cfTitle.match(/\bUS\b/) == null) {
+      dTitle = capitalizeFirstLetter(localStorage.cfTitle);
+    } else {
+      dTitle = localStorage.cfTitle;
+    }
+    const ourTitle = "This week's theme: " + dTitle;
+    const ourTableTitle = "This week's theme:<br> " + dTitle;
+    theDiv.prepend("<h2 class='thisWeeksTheme'>" + ourTitle + "</h2>");
+    if ($("#themeTable").length) {
+      $("#themeTable").find("caption").html(ourTableTitle);
+      $("h2.thisWeeksTheme").hide();
+    }
+  }
+  const motwLink = theP.find("a:contains(" + localStorage.motw + ")");
+  motwLink.text(motwLink.text().replace(/\bfrom\b/, "from our Member of the Week,"));
+  const mSplits = motwLink.text().split("our Member of the Week");
+  const boldText = document.createElement("b");
+  boldText.append(document.createTextNode("our Member of the Week"));
+  motwLink.text("");
+  motwLink.append(document.createTextNode(mSplits[0]), boldText, document.createTextNode(mSplits[1]));
+}
+
+async function connectionsBanner() {
+  getThemeData().then((response) => {
+    if ($("h2.thisWeeksTheme").length == 0) {
+      if (
+        $(
+          "div.sixteen.columns p a[href*='Special:Connection'],div.sixteen.columns div.box.rounded.row a[href*='Special:Connection']"
+        ).length
+      ) {
+        const firstConnection = $(
+          "div.sixteen.columns p a[href*='Special:Connection'],div.sixteen.columns div.box.rounded.row a[href*='Special:Connection']"
+        )
+          .eq(0)
+          .text()
+          .replace(/[0-9]+ degrees? from /, "");
+
+        const firstConnectionHREF = $(
+          "div.sixteen.columns p a[href*='Special:Connection'],div.sixteen.columns div.box.rounded.row a[href*='Special:Connection']"
+        )
+          .eq(0)
+          .attr("href");
+
+        if (isOK(firstConnectionHREF)) {
+          const urlParams = new URLSearchParams(firstConnectionHREF);
+          console.log(firstConnectionHREF);
+          const firstConnectionWTID = urlParams.get("person1Name");
+          localStorage.setItem("firstConnectionWTID", firstConnectionWTID);
+          const homePageURL = "https://www.wikitree.com";
+          $.ajax({
+            url: homePageURL,
+            success: function (data) {
+              if ($("h2.thisWeeksTheme").length == 0) {
+                const hpHTML = $(data);
+                let linkText = "";
+                if (isOK(localStorage.shogenCFTitleData)) {
+                  linkText = JSON.parse(localStorage.shogenCFTitleData)["linkText"];
+                } else {
+                  linkText = "closely-connected";
+                }
+                let cfTitle = hpHTML
+                  .find("a[href*='" + linkText + "'][title*='G2G post']")
+                  .eq(0)
+                  .text();
+
+                let gotFromShogen = false;
+                let cfTitleOverride = false;
+                if (isOK(cfTitle) && isOK(localStorage.shogenCFTitleData)) {
+                  const themeData = JSON.parse(localStorage.shogenCFTitleData);
+                  if (themeData.theme == "null") {
+                    cfTitle = "";
+                  } else if (themeData.theme != "") {
+                    //cfTitle = themeData.theme;
+                    localStorage.shogenCFTitle = themeData.theme;
+                    let cfTitleOverride = true;
+                  } else {
+                    themeData.themes.forEach(function (aTheme) {
+                      const cfRegExp = new RegExp(aTheme[0], "i");
+                      if (cfTitle.match(cfRegExp) != null) {
+                        cfTitle = aTheme[1];
+                        localStorage.shogenCFTitle = cfTitle;
+                        gotFromShogen = true;
+                      }
+                    });
+                  }
+                }
+                if (gotFromShogen == false) {
+                  if (isOK(localStorage.shogenCFTitle)) {
+                    cfTitle = localStorage.shogenCFTitle;
+                  }
+                  if (localStorage.shogenCFTitle == "null") {
+                    cfTitle = "";
+                  }
+                }
+                localStorage.setItem("cfTitle", cfTitle);
+                localStorage.setItem("firstConnection", firstConnection);
+                const mow = hpHTML.find("span.large:contains(Member of the Week)");
+                if (mow.length) {
+                  localStorage.motw = mow.parent().find("img").attr("alt");
+                }
+                setConnectionsBanner();
+              }
+            },
+          });
         }
       }
-    });
+    }
   });
+}
+
+async function getThemeData() {
+  // get theme data
+  const beeURL = "https://wikitreebee.com/BEE.php?q=BEE";
+  const result = await $.ajax({
+    url: beeURL,
+    crossDomain: true,
+    xhrFields: { withCredentials: false },
+    type: "POST",
+    dataType: "text",
+    success: function (data) {
+      const mData = JSON.parse(data);
+      localStorage.shogenCFTitle = mData.theme;
+      localStorage.shogenCFTitleData = data;
+    },
+    error: function (jqXHR, textStatus, error) {
+      console.log("error in AJAX call...");
+      console.log("jqXHR:", jqXHR);
+      console.log("textStatus:", textStatus);
+      console.log("error:", error);
+    },
+  });
+  return result;
 }

--- a/src/features/sort_theme_people/sort_theme_people.js
+++ b/src/features/sort_theme_people/sort_theme_people.js
@@ -1,12 +1,8 @@
 import $ from "jquery";
 import "./sort_theme_people.css";
-import {
-  getRelationshipFinderResult,
-  ordinalWordToNumberAndSuffix,
-} from "../distanceAndRelationship/distanceAndRelationship";
 import { capitalizeFirstLetter } from "../familyTimeline/familyTimeline";
 import { isOK } from "../../core/common.js";
-import { checkIfFeatureEnabled, getFeatureOptions } from "../../core/options/options_storage";
+import { checkIfFeatureEnabled } from "../../core/options/options_storage";
 
 checkIfFeatureEnabled("sortThemePeople").then((result) => {
   if (
@@ -17,14 +13,7 @@ checkIfFeatureEnabled("sortThemePeople").then((result) => {
     if ($("h2.thisWeeksTheme").length == 0) {
       connectionsBanner();
     }
-    $(".sixteen p a:contains(degrees from),.sixteen div.box.rounded.row a:contains(degrees from)")
-      .closest("div")
-      .before($("<button id='themeTableButton' class='small button'>Theme list</button>"));
-    $("#themeTableButton").on("click", function (e) {
-      e.preventDefault();
-      themePeopleTable();
-    });
-    // themePeopleTable();
+    themePeopleTable();
   }
 });
 
@@ -69,33 +58,6 @@ function themePeopleTable() {
       );
       themeTable.find("tbody").append(aRow);
       const profileID = $("a.pureCssMenui0 span.person").text();
-      getRelationshipFinderResult(profileID, aPerson.WTID).then((data) => {
-        if (data) {
-          var out = "";
-          var aRelationship = true;
-          const commonAncestors = [];
-          let realOut = "";
-          let dummy = $("<html></html>");
-          dummy.append($(data.html));
-          if (dummy.find("h1").length) {
-            if (dummy.find("h1").eq(0).text() == "No Relationship Found") {
-              aRelationship = false;
-              console.log("No Relationship Found");
-            }
-          }
-          if (dummy.find("h2").length && aRelationship == true) {
-            let out = dummy.find("h2").eq(0).text().trim();
-            $("#themeTable a[href$='" + aPerson.WTID + "']")
-              .closest("tr")
-              .find("td:last")
-              .append(
-                $(
-                  `<a href='https://www.wikitree.com/index.php?title=Special:Relationship&action=calculate&person1_name=${profileID}&person2_name=${aPerson.WTID}'>${out}</a>`
-                )
-              );
-          }
-        }
-      });
     });
   }
 }
@@ -116,7 +78,7 @@ async function setConnectionsBanner() {
       dTitle = localStorage.cfTitle;
     }
     const ourTitle = "This week's theme: " + dTitle;
-    const ourTableTitle = "This week's theme:<br> " + dTitle;
+    const ourTableTitle = dTitle + ":<br>Connections to " + $("span[itemprop='givenName']").text();
     theDiv.prepend("<h2 class='thisWeeksTheme'>" + ourTitle + "</h2>");
     if ($("#themeTable").length) {
       $("#themeTable").find("caption").html(ourTableTitle);
@@ -155,7 +117,6 @@ async function connectionsBanner() {
 
         if (isOK(firstConnectionHREF)) {
           const urlParams = new URLSearchParams(firstConnectionHREF);
-          console.log(firstConnectionHREF);
           const firstConnectionWTID = urlParams.get("person1Name");
           localStorage.setItem("firstConnectionWTID", firstConnectionWTID);
           const homePageURL = "https://www.wikitree.com";

--- a/src/features/sort_theme_people/sort_theme_people.js
+++ b/src/features/sort_theme_people/sort_theme_people.js
@@ -10,9 +10,7 @@ checkIfFeatureEnabled("sortThemePeople").then((result) => {
     $("body.profile").length &&
     $(".sixteen p a:contains(degrees from),.sixteen div.box.rounded.row a:contains(degrees from)").length
   ) {
-    if ($("h2.thisWeeksTheme").length == 0) {
-      connectionsBanner();
-    }
+    connectionsBanner();
     themePeopleTable();
   }
 });

--- a/src/manifest/manifest-firefox.json
+++ b/src/manifest/manifest-firefox.json
@@ -7,7 +7,7 @@
 		"page": "options.html",
 		"open_in_tab": true
 	},
-	"permissions": [ "https://www.wikitree.com/*", "https://api.wikitree.com/*", "storage" ],
+	"permissions": [ "https://www.wikitree.com/*", "https://api.wikitree.com/*", "https://wikitreebee.com/*", "storage" ],
 	"content_scripts": [
 		{
 			"matches": [ "https://www.wikitree.com/*" ],

--- a/src/manifest/manifest-firefox.json
+++ b/src/manifest/manifest-firefox.json
@@ -7,7 +7,7 @@
 		"page": "options.html",
 		"open_in_tab": true
 	},
-	"permissions": [ "https://www.wikitree.com/*", "https://api.wikitree.com/*", "https://wikitreebee.com/*", "storage" ],
+	"permissions": [ "https://www.wikitree.com/*", "https://api.wikitree.com/*", "https://wikitree.sdms.si/*","https://wikitreebee.com/*", "storage" ],
 	"content_scripts": [
 		{
 			"matches": [ "https://www.wikitree.com/*" ],


### PR DESCRIPTION
This is for the connection finder theme people at the bottom of profiles.  It gets a theme title from either the home page or my server.  Then it adds a 'Theme List' button.  Clicking this sorts the people into a table ordered by degree from the profile person.  It also gets the Relationship Finder results for the profile person and the featured people and puts any positive results in the table.

I'd appreciate any input on this - things like the name or design.