### PR TITLE
Collapsible Sources

### DIFF
--- a/src/content.js
+++ b/src/content.js
@@ -10,6 +10,7 @@ import "./features/categoryDisplay/categoryDisplay";
 import "./features/categoryFinderPins/categoryFinderPins";
 import "./features/clipboard_and_notes/clipboard_and_notes";
 import "./features/collapsibleDescendantsTree/collapsibleDescendantsTree";
+import "./features/collapsible_sources/collapsible_sources";
 import "./features/darkMode/darkMode";
 import "./features/distanceAndRelationship/distanceAndRelationship";
 import "./features/draftList/draftList";

--- a/src/features/collapsible_sources/collapsible_sources.css
+++ b/src/features/collapsible_sources/collapsible_sources.css
@@ -1,0 +1,5 @@
+#toggleSources {
+  font-size: 0.5em;
+  padding: 0.8em;
+  float: right;
+}

--- a/src/features/collapsible_sources/collapsible_sources.js
+++ b/src/features/collapsible_sources/collapsible_sources.js
@@ -1,0 +1,41 @@
+import $ from "jquery";
+import "./collapsible_sources.css";
+import { checkIfFeatureEnabled } from "../../core/options/options_storage";
+
+checkIfFeatureEnabled("collapsibleSources").then((result) => {
+  if (result && $("#toggleSources").length == 0) {
+    collapsibleSources();
+  }
+});
+
+function toggleSources() {
+  return function () {
+    if ($(this).text() == "▶") {
+      $(this).text("▼");
+      $("ol.references").slideDown();
+    } else {
+      $(this).text("▶");
+      $("ol.references").slideUp();
+    }
+  };
+}
+
+async function collapsibleSources() {
+  if ($("body.profile").length && window.location.href.match("Space:") == null && $("ol.references li").length) {
+    $("ol.references").hide();
+    $("h2 span.mw-headline:contains(Sources)").append(
+      $("<button id='toggleSources' title='Toggle inline sources' class='small'>▶</button>")
+    );
+    $("#toggleSources").on("click", toggleSources());
+
+    $("sup.reference a").on("click", function (e) {
+      e.preventDefault();
+      let theNote = $(this).attr("href");
+      $("ol.references").slideDown();
+      $("#toggleSources").text("▼");
+      setTimeout(function () {
+        window.location = theNote;
+      }, 500);
+    });
+  }
+}

--- a/src/features/register_feature_options.js
+++ b/src/features/register_feature_options.js
@@ -68,6 +68,17 @@ registerFeature({
 });
 
 registerFeature({
+  name: "Collapsible Sources",
+  id: "collapsibleSources",
+  description:
+    "Makes the page shorter by hiding the inline citations on load.  " +
+    "To see the inline citations, click the ▶ button next to the Sources heading, click the superscript number of the citation, " +
+    "or use the Source Preview feature of this extension.",
+  category: "Profile",
+  defaultValue: false,
+});
+
+registerFeature({
   name: "Distance and Relationship",
   id: "distanceAndRelationship",
   description: "Adds the distance (degrees) between you and the profile person and any relationship between you.",


### PR DESCRIPTION
To make a profile page shorter, this collapses inline citations onload.  To see the inline citations, click the ▶ button next to the Sources heading, click the superscript number of the citation, or use the Source Preview feature of this extension.