### PR TITLE
Add WT+ To Firefox Manifest

### DIFF
--- a/src/manifest/manifest-firefox.json
+++ b/src/manifest/manifest-firefox.json
@@ -7,7 +7,7 @@
 		"page": "options.html",
 		"open_in_tab": true
 	},
-	"permissions": [ "https://www.wikitree.com/*",  "https://api.wikitree.com/*", "storage" ],
+	"permissions": [ "https://www.wikitree.com/*",  "https://api.wikitree.com/*", "https://wikitree.sdms.si/*","storage" ],
 	"content_scripts": [
 		{
 			"matches": [ "https://www.wikitree.com/*" ],


### PR DESCRIPTION
The WT+ part of the extension needs this.