### PR TITLE
StickyToolbar

### DIFF
--- a/src/content.js
+++ b/src/content.js
@@ -33,6 +33,7 @@ import "./features/sortBadges/sortBadges";
 import "./features/sort_theme_people/sort_theme_people";
 import "./features/sourcepreview/sourcepreview";
 import "./features/spacepreview/spacepreview";
+import "./features/sticky_toolbar/sticky_toolbar";
 import "./features/verifyID/verifyID";
 import "./features/what_links_here/what_links_here";
 import "./features/wtPlus/wtPlus";

--- a/src/features/register_feature_options.js
+++ b/src/features/register_feature_options.js
@@ -199,6 +199,14 @@ registerFeature({
 });
 
 registerFeature({
+  name: "Sticky Toolbar",
+  id: "stickyToolbar",
+  description: "Makes the toolbar on the editor on edit pages stick to the top of the screen and not scroll out of sight.",
+  category: "Editing",
+  defaultValue: true,
+});
+
+registerFeature({
   name: "Verify ID",
   id: "verifyID",
   description:

--- a/src/features/sticky_toolbar/sticky_toolbar.css
+++ b/src/features/sticky_toolbar/sticky_toolbar.css
@@ -1,0 +1,6 @@
+#toolbar.sticky {
+  position: sticky;
+  top: 0;
+  background: white;
+  z-index: 100000;
+}

--- a/src/features/sticky_toolbar/sticky_toolbar.js
+++ b/src/features/sticky_toolbar/sticky_toolbar.js
@@ -1,0 +1,12 @@
+import $ from "jquery";
+import "./sticky_toolbar.css";
+import { checkIfFeatureEnabled } from "../../core/options/options_storage";
+
+checkIfFeatureEnabled("stickyToolbar").then((result) => {
+  if (result && $("body.page-Special_EditPerson").length) {
+    setTimeout(function () {
+      $("#editToolbarExt").appendTo($("#toolbar"));
+    }, 5000);
+    $("#toolbar").addClass("sticky");
+  }
+});


### PR DESCRIPTION
Makes the toolbar on the editor on edit pages stick to the top of the screen and not scroll out of sight.