### PR TITLE
Stop flashing

### DIFF
--- a/src/features/clipboard_and_notes/clipboard_and_notes.js
+++ b/src/features/clipboard_and_notes/clipboard_and_notes.js
@@ -1,6 +1,7 @@
 import $ from "jquery";
 import "jquery-ui/ui/widgets/sortable";
 import "jquery-ui/ui/widgets/draggable";
+import "./clipboard_and_notes.css";
 import { htmlEntities } from "../../core/common";
 import { checkIfFeatureEnabled, getFeatureOptions } from "../../core/options/options_storage";
 
@@ -22,7 +23,6 @@ export function appendClipboardButtons(clipboardButtons = $()) {
 
 checkIfFeatureEnabled("clipboardAndNotes").then((result) => {
   if (result && $(".clipboardButtons").length == 0) {
-    import("./clipboard_and_notes.css");
     // BEE class
     window.clipboardClicker = $();
     window.lastClipboardClicker = $();

--- a/src/features/extra_watchlist/extra_watchlist.js
+++ b/src/features/extra_watchlist/extra_watchlist.js
@@ -2,13 +2,13 @@ import $ from "jquery";
 import Cookies from "js-cookie";
 import "jquery-ui/ui/widgets/draggable";
 import "../../thirdparty/date.format.js";
+import "./extra_watchlist.css";
 import { isOK, htmlEntities, displayName } from "../../core/common";
 import { appendClipboardButtons } from "../clipboard_and_notes/clipboard_and_notes";
 import { checkIfFeatureEnabled, getFeatureOptions } from "../../core/options/options_storage";
 
 checkIfFeatureEnabled("extraWatchlist").then((result) => {
   if (result && $("body.page-Special_EditFamily,body.page-Special_EditPerson").length == 0) {
-    import("./extra_watchlist.css");
     extraWatchlist();
   }
 });


### PR DESCRIPTION
Moved the CSS import back to the top level as its late loading caused the buttons to kind of flash as they take the rules of the WT buttons before the CSS to modify them.