### PR TITLE
Fix G2G style and Sticky Toolbar

### DIFF
--- a/src/features/g2g/g2g.css
+++ b/src/features/g2g/g2g.css
@@ -10,39 +10,12 @@
 
 .g2gPlus {
   position: absolute;
-  /*
-      bottom:0.5em;
-      right:0.5em;
-      */
   margin-top: 1.1em;
   margin-left: -0.7em;
   font-weight: bold;
-  /*border:1px solid forestgreen; */
   border-radius: 50%;
   line-height: 0.7em;
   color: forestgreen;
-}
-
-.g2g {
-  float: right;
-  border: 0;
-}
-#wtIDgo_label {
-  padding: 0;
-}
-.g2g input#wtIDgo_go,
-.g2g #wtIDgo_label input {
-  font-size: 1.3em;
-}
-
-.g2g input#wtIDgo_go {
-  height: 70%;
-  margin-top: 5%;
-  padding: 2px;
-}
-
-.g2g #wtIDgo_id {
-  height: 1em;
 }
 
 ul.qa-nav-cat-list a {

--- a/src/features/g2g/g2g.js
+++ b/src/features/g2g/g2g.js
@@ -147,7 +147,7 @@ function addWikiIDGoBox() {
     );
 
     $("#wtIDgo_id").on("keyup", function (up) {
-      if (up.keyCode == 13) {
+      if (up.key == "Enter") {
         $("#wtIDgo_go").trigger("click");
       }
     });
@@ -155,7 +155,12 @@ function addWikiIDGoBox() {
     $("#wtIDgo_go").on("click", function (ev) {
       ev.preventDefault();
       const wtID = $("#wtIDgo_id");
-      window.location = "https://wikitree.com/wiki/" + $("#wtIDgo_id").val().trim();
+      const thisValue = $("#wtIDgo_id").val().trim();
+      if (thisValue.match(/[0-9]/) == null) {
+        window.location = "https://www.wikitree.com/genealogy/" + thisValue;
+      } else {
+        window.location = "https://wikitree.com/wiki/" + thisValue;
+      }
     });
   }
 }

--- a/src/features/g2g/g2g.js
+++ b/src/features/g2g/g2g.js
@@ -1,5 +1,5 @@
 import $ from "jquery";
-
+import "./g2g_.css";
 import { isOK } from "../../core/common";
 import Cookies from "js-cookie";
 import { checkIfFeatureEnabled, getFeatureOptions } from "../../core/options/options_storage";

--- a/src/features/g2g/g2g_.css
+++ b/src/features/g2g/g2g_.css
@@ -1,0 +1,22 @@
+.g2g {
+  float: right;
+  border: 0;
+}
+
+#wtIDgo_label {
+  padding: 0;
+}
+.g2g input#wtIDgo_go,
+.g2g #wtIDgo_label input {
+  font-size: 1.3em;
+}
+
+.g2g input#wtIDgo_go {
+  height: 70%;
+  margin-top: 5%;
+  padding: 2px;
+}
+
+.g2g #wtIDgo_id {
+  height: 1em;
+}

--- a/src/features/sticky_toolbar/sticky_toolbar.css
+++ b/src/features/sticky_toolbar/sticky_toolbar.css
@@ -2,5 +2,5 @@
   position: sticky;
   top: 0;
   background: white;
-  z-index: 100000;
+  z-index: 19;
 }

--- a/src/features/sticky_toolbar/sticky_toolbar.js
+++ b/src/features/sticky_toolbar/sticky_toolbar.js
@@ -3,7 +3,11 @@ import "./sticky_toolbar.css";
 import { checkIfFeatureEnabled } from "../../core/options/options_storage";
 
 checkIfFeatureEnabled("stickyToolbar").then((result) => {
-  if (result && $("body.page-Special_EditPerson").length) {
+  if (
+    result &&
+    ($("body.page-Special_EditPerson").length ||
+      (window.location.href.match(/Project:|Category:|Space:/) && $("#toolbar").length))
+  ) {
     setTimeout(function () {
       $("#editToolbarExt").appendTo($("#toolbar"));
     }, 5000);


### PR DESCRIPTION
Avoid some flashing. 
+ Re-direct entries without numbers in the WTID Go box to the 'genealogy' page.