### PR TITLE
Scissors

### DIFF
--- a/src/content.js
+++ b/src/content.js
@@ -31,6 +31,7 @@ import "./features/my_menu/my_menu";
 import "./features/printerfriendly/printerfriendly";
 import "./features/randomProfile/randomProfile";
 import "./features/redir_ext_links/redir_ext_links";
+import "./features/scissors/scissors";
 import "./features/sortBadges/sortBadges";
 import "./features/sort_theme_people/sort_theme_people";
 import "./features/sourcepreview/sourcepreview";

--- a/src/features/g2g/g2g.js
+++ b/src/features/g2g/g2g.js
@@ -82,7 +82,7 @@ function g2gScissors() {
   }
 }
 
-function copyThingToClipboard(thing) {
+export function copyThingToClipboard(thing) {
   const $temp = $("<input>");
   $("body").prepend($temp);
   $temp.val(thing).select();

--- a/src/features/register_feature_options.js
+++ b/src/features/register_feature_options.js
@@ -177,6 +177,15 @@ registerFeature({
 });
 
 registerFeature({
+  name: "Scissors",
+  id: "scissors",
+  description:
+    "Adds scissors (like on profile pages) to Category, Help, and Change Details pages to copy various things.",
+  category: "Other",
+  defaultValue: true,
+});
+
+registerFeature({
   name: "Sort Badges",
   id: "sortBadges",
   description: "Buttons to move or hide your Club 100/1000 badges.",
@@ -212,7 +221,8 @@ registerFeature({
 registerFeature({
   name: "Sticky Toolbar",
   id: "stickyToolbar",
-  description: "Makes the toolbar on the editor on edit pages stick to the top of the screen and not scroll out of sight.",
+  description:
+    "Makes the toolbar on the editor on edit pages stick to the top of the screen and not scroll out of sight.",
   category: "Editing",
   defaultValue: true,
 });

--- a/src/features/scissors/scissors.js
+++ b/src/features/scissors/scissors.js
@@ -39,17 +39,23 @@ function helpScissors() {
       });
     }
   }
-  if ($("h1:contains('Change Details')").length) {
+  if ($("td.diff-lineno:contains('Bio Changes')").length) {
     const historyItem = $("span.HISTORY-ITEM");
-    let adderA = $("td:contains(Changes made by)").find("a");
+    let change = "Added";
+    if (historyItem.find("a:contains(created),a:contains(imported the data)").length) {
+      change = "Created";
+    }
+    const changesMadeBy = $("td:contains(Changes made by)");
+    const theDate = changesMadeBy.text().match(/[0-9]+ [A-Z][a-z]+ [0-9]{4}/);
+    let adderA = changesMadeBy.find("a").eq(0);
     let adderID = adderA.attr("href").split("wiki/")[1];
     let adderName = adderA.text();
-    let reference = "[" + url + " Added] by [[" + adderID + "|" + adderName + "]]";
+    let reference = "[" + url + " " + change + "] by [[" + adderID + "|" + adderName + "]] on " + theDate + ".";
     adderA
       .parent()
       .append(
         $(
-          '<span id="helpScissors"><button aria-label="Copy ID" title="Copy ID" data-copy-label="Copy ID" class="copyWidget" data-copy-text="' +
+          '<span id="helpScissors"><button aria-label="Copy Reference" title="Copy reference to your clipboard" data-copy-label="Copy Reference" class="copyWidget" data-copy-text="' +
             reference +
             '" style="color:#8fc641;"><img src="/images/icons/scissors.png">Reference</button></span>'
         )

--- a/src/features/scissors/scissors.js
+++ b/src/features/scissors/scissors.js
@@ -1,0 +1,65 @@
+import $ from "jquery";
+import { copyThingToClipboard } from "../g2g/g2g";
+import { checkIfFeatureEnabled, getFeatureOptions } from "../../core/options/options_storage";
+
+checkIfFeatureEnabled("scissors").then((result) => {
+  if (result) {
+    import("./scissors.css");
+    helpScissors();
+  }
+});
+
+function helpScissors() {
+  const url = decodeURIComponent(window.location.href);
+  if (window.location.href.match(/\wiki\/Help|Category:/)) {
+    const helpIDmatch = url.match(/Help|Category.*/);
+    let helpLink = "[" + url + " " + helpIDmatch + "]";
+    const categoryIDmatch = url.match(/Category.*/);
+    if (categoryIDmatch != null) {
+      helpLink = "[[:" + helpIDmatch + "]]";
+    }
+    if (helpIDmatch != null) {
+      window.helpID = helpIDmatch[0];
+      const helpQuestion = $("h1").text();
+      $("h1").append(
+        $(
+          '<span id="helpScissors"><button aria-label="Copy ID" title="Copy ID" data-copy-label="Copy ID" class="copyWidget" data-copy-text="' +
+            helpID +
+            '" style="color:#8fc641;"><img src="/images/icons/scissors.png">ID</button><button aria-label="Copy Link" title="Copy Link" data-copy-label="Copy Link" class="copyWidget" data-copy-text="' +
+            helpLink +
+            '" style="color:#8fc641;">/Link</button><button aria-label="Copy URL" title="Copy URL" data-copy-label="Copy URL" class="copyWidget" data-copy-text="' +
+            url +
+            '" style="color:#8fc641;">/URL</button></span>'
+        )
+      );
+
+      $("#helpScissors button").on("click", function (e) {
+        e.preventDefault();
+        copyThingToClipboard($(this).attr("data-copy-text"));
+      });
+    }
+  }
+  if ($("h1:contains('Change Details')").length) {
+    const historyItem = $("span.HISTORY-ITEM");
+    let adderA = $("td:contains(Changes made by)").find("a");
+    let adderID = adderA.attr("href").split("wiki/")[1];
+    let adderName = adderA.text();
+    let reference = "[" + url + " Added] by [[" + adderID + "|" + adderName + "]]";
+    adderA
+      .parent()
+      .append(
+        $(
+          '<span id="helpScissors"><button aria-label="Copy ID" title="Copy ID" data-copy-label="Copy ID" class="copyWidget" data-copy-text="' +
+            reference +
+            '" style="color:#8fc641;"><img src="/images/icons/scissors.png">Reference</button></span>'
+        )
+      );
+
+    $("#helpScissors button").on("click", function (e) {
+      e.preventDefault();
+      copyThingToClipboard($(this).attr("data-copy-text"));
+    });
+  }
+}
+
+// [https://www.wikitree.com/index.php?title=Badenhorst-1834&diff=150484891&oldid=150484325 Added] by [[Smit-641|Riël Smit]] on 24 May 2022.

--- a/src/features/scissors/scissors.js
+++ b/src/features/scissors/scissors.js
@@ -5,7 +5,9 @@ import { checkIfFeatureEnabled, getFeatureOptions } from "../../core/options/opt
 checkIfFeatureEnabled("scissors").then((result) => {
   if (result) {
     import("./scissors.css");
-    helpScissors();
+    if ($("#helpScissors").length == 0) {
+      helpScissors();
+    }
   }
 });
 

--- a/src/features/scissors/scissors.js
+++ b/src/features/scissors/scissors.js
@@ -67,5 +67,3 @@ function helpScissors() {
     });
   }
 }
-
-// [https://www.wikitree.com/index.php?title=Badenhorst-1834&diff=150484891&oldid=150484325 Added] by [[Smit-641|Riël Smit]] on 24 May 2022.


### PR DESCRIPTION
Adds scissors (Copy ID/Link/URL) to Help and Category pages, and a (requested) 'Reference' button on the Change Details page(s) in this format: 
[https://www.wikitree.com/index.php?title=Badenhorst-1834&diff=150484891&oldid=150484325 Added] by [[Smith-123|John Smith]] on 24 May 2022.  

