### PR TITLE
Suggested matches filter

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wikitree-browser-extension",
-  "version": "1.0.5.1",
+  "version": "1.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "wikitree-browser-extension",
-      "version": "1.0.4",
+      "version": "1.1.0",
       "dependencies": {
         "jquery": "^3.6.1",
         "jquery-ui": "^1.13.2",

--- a/src/content.js
+++ b/src/content.js
@@ -39,6 +39,7 @@ import "./features/sort_theme_people/sort_theme_people";
 import "./features/sourcepreview/sourcepreview";
 import "./features/spacepreview/spacepreview";
 import "./features/sticky_toolbar/sticky_toolbar";
+import "./features/suggested_matches_filters/suggested_matches_filters";
 import "./features/verifyID/verifyID";
 import "./features/what_links_here/what_links_here";
 import "./features/wtPlus/wtPlus";

--- a/src/features/dna_table/dna_table.js
+++ b/src/features/dna_table/dna_table.js
@@ -98,7 +98,7 @@ checkIfFeatureEnabled("dnaTable").then((result) => {
   }
 });
 
-async function getPeople(keys, siblings, ancestors, descendants, nuclear, minGeneration, fields) {
+export async function getPeople(keys, siblings, ancestors, descendants, nuclear, minGeneration, fields) {
   try {
     const result = await $.ajax({
       url: "https://api.wikitree.com/api.php",

--- a/src/features/register_feature_options.js
+++ b/src/features/register_feature_options.js
@@ -246,6 +246,14 @@ registerFeature({
 });
 
 registerFeature({
+  name: "Suggested Matches Filters",
+  id: "suggestedMatchesFilters",
+  description: "Lets you filter out suggested matches for new profiles by name and/or location.",
+  category: "Editing",
+  defaultValue: true,
+});
+
+registerFeature({
   name: "Verify ID",
   id: "verifyID",
   description:

--- a/src/features/suggested_matches_filters/suggested_matches_filters.css
+++ b/src/features/suggested_matches_filters/suggested_matches_filters.css
@@ -1,4 +1,6 @@
-#potentialMatchesSection tr.locationFiltered {
+#potentialMatchesSection tr.locationFiltered,
+#potentialMatchesSection tr.nameFiltered,
+#potentialMatchesSection tr.dateFiltered {
   display: none;
 }
 #filterButtons {

--- a/src/features/suggested_matches_filters/suggested_matches_filters.css
+++ b/src/features/suggested_matches_filters/suggested_matches_filters.css
@@ -1,0 +1,6 @@
+#potentialMatchesSection tr.locationFiltered {
+  display: none;
+}
+#filterButtons {
+  float: right;
+}

--- a/src/features/suggested_matches_filters/suggested_matches_filters.js
+++ b/src/features/suggested_matches_filters/suggested_matches_filters.js
@@ -223,13 +223,17 @@ async function initSuggestedMatchesFilters() {
   });
   const relativeTypes = ["Parents", "Siblings", "Spouses", "Children"];
   let keys, aPerson;
-  relativeTypes.forEach(function (relativeType) {
-    keys = Object.keys(relatives[0][relativeType]);
-    keys.forEach(function (aKey) {
-      aPerson = relatives[0][relativeType][aKey];
-      locations.push(aPerson.BirthLocation, aPerson.DeathLocation);
+  if (relatives[0]) {
+    relativeTypes.forEach(function (relativeType) {
+      if (relatives[0][relativeType]) {
+        keys = Object.keys(relatives[0][relativeType]);
+        keys.forEach(function (aKey) {
+          aPerson = relatives[0][relativeType][aKey];
+          locations.push(aPerson.BirthLocation, aPerson.DeathLocation);
+        });
+      }
     });
-  });
+  }
 
   const filteredLocations = [];
   let trimmedBit, aLocationBits;

--- a/src/features/suggested_matches_filters/suggested_matches_filters.js
+++ b/src/features/suggested_matches_filters/suggested_matches_filters.js
@@ -117,7 +117,7 @@ function addUSVariants(person) {
 }
 
 function locationFilter(person, filteredLocations, newPerson) {
-  let thisTR = $("a[href$='" + person.WTID + "']").closest("tr");
+  let thisTR = $(`a[href\$="${person.WTID}"]`).closest("tr");
   let matchCount = 0;
   person.locations.forEach(function (aLocation) {
     if (filteredLocations.includes(aLocation)) {
@@ -204,7 +204,7 @@ function dateFilter(level, newPerson) {
   let personYear3, newPersonYear3, filterOut;
   suggestedMatches.forEach(function (person) {
     filterOut = false;
-    let thisTR = $("a[href$='" + person.WTID + "']").closest("tr");
+    let thisTR = $(`a[href\$="${person.WTID}"]`).closest("tr");
     if (person.BirthYear) {
       if (person.BirthYear.match("s")) {
         personYear3 = person.BirthYear.substring(0, 3);
@@ -383,7 +383,7 @@ async function initSuggestedMatchesFilters() {
     if (person.locations.length == 0) {
       getLocations(person.WTID).then((oLocations) => {
         person.locations = oLocations;
-        let thisTD = $("a[href$='" + person.WTID + "']").closest("td");
+        let thisTD = $(`a[href\$="${person.WTID}"]`).closest("td");
         let locationWords = person.locations.join(", ");
         if (person.locations.length) {
           thisTD.append("<div>Family location words: " + locationWords + "</div>");

--- a/src/features/suggested_matches_filters/suggested_matches_filters.js
+++ b/src/features/suggested_matches_filters/suggested_matches_filters.js
@@ -43,7 +43,6 @@ function addNewPersonToH1() {
     " - " +
     newPerson.DeathYear +
     ")";
-  console.log(newPerson);
   $("#newPersonSummary").remove();
   $("h1").append($("<span id='newPersonSummary'>&rarr; " + newPerson.summary + "</span>"));
 }
@@ -173,7 +172,6 @@ function dateFilter(level, newPerson) {
   suggestedMatches.forEach(function (person) {
     filterOut = false;
     let thisTR = $("a[href$='" + person.WTID + "']").closest("tr");
-    console.log(person.BirthYear);
     if (person.BirthYear) {
       if (person.BirthYear.match("s")) {
         personYear3 = person.BirthYear.substring(0, 3);

--- a/src/features/suggested_matches_filters/suggested_matches_filters.js
+++ b/src/features/suggested_matches_filters/suggested_matches_filters.js
@@ -206,7 +206,6 @@ function dateFilter(level, newPerson) {
     filterOut = false;
     let thisTR = $("a[href$='" + person.WTID + "']").closest("tr");
     if (person.BirthYear) {
-      console.log(person, newPerson);
       if (person.BirthYear.match("s")) {
         personYear3 = person.BirthYear.substring(0, 3);
         newPersonYear3 = newPerson.BirthYear.substring(0, 3);
@@ -224,7 +223,6 @@ function dateFilter(level, newPerson) {
       ) {
         filterOut = true;
       }
-      console.log(yearsOut, person.BirthYear, newPerson.BirthYear);
       if (filterOut == true) {
         thisTR.addClass("dateFiltered");
       }

--- a/src/features/suggested_matches_filters/suggested_matches_filters.js
+++ b/src/features/suggested_matches_filters/suggested_matches_filters.js
@@ -1,0 +1,564 @@
+import $ from "jquery";
+import "./suggested_matches_filters.css";
+import { checkIfFeatureEnabled } from "../../core/options/options_storage";
+import { getRelatives } from "wikitree-js";
+import { isOK } from "../../core/common";
+
+checkIfFeatureEnabled("suggestedMatchesFilters").then((result) => {
+  if (result && $("body.page-Special_EditFamilySteps")) {
+    $("#enterBasicDataButton").on("click", function () {
+      checkReady();
+    });
+  }
+});
+
+function checkReady() {
+  if ($("#potentialMatchesSection table").length) {
+    initSuggestedMatchesFilters();
+  } else {
+    setTimeout(function () {
+      checkReady();
+    }, 1000);
+  }
+}
+
+async function initSuggestedMatchesFilters() {
+  const WTID = $("h1 button[aria-label='Copy ID']").data("copy-text");
+  const relatives = await getRelatives([WTID], {
+    getSpouses: true,
+    getChildren: true,
+    getParents: true,
+    getSiblings: true,
+    fields: ["BirthLocation,DeathLocation"],
+  });
+  const locations = [
+    relatives[0]?.BirthLocation,
+    relatives[0]?.DeathLocation,
+    $("#mBirthLocation").val(),
+    $("#mDeatthLocation").val(),
+  ];
+  const newPerson = {};
+  newPerson.locations = [];
+  newPerson.FirstName = $("#mFirstName").val().trim();
+  let birthDeath = ["Birth", "Death"];
+  birthDeath.forEach(function (bd) {
+    $("#m" + bd + "Location")
+      .val()
+      .split(",")
+      .forEach(function (aBit) {
+        newPerson.locations.push(aBit.trim());
+      });
+  });
+  const relativeTypes = ["Parents", "Siblings", "Spouses", "Children"];
+  let keys, aPerson;
+  relativeTypes.forEach(function (relativeType) {
+    keys = Object.keys(relatives[0][relativeType]);
+    keys.forEach(function (aKey) {
+      aPerson = relatives[0][relativeType][aKey];
+      locations.push(aPerson.BirthLocation, aPerson.DeathLocation);
+    });
+  });
+
+  const filteredLocations = [];
+  let trimmedBit, aLocationBits;
+  locations.forEach(function (aLocation) {
+    if (isOK(aLocation)) {
+      aLocationBits = aLocation.split(",");
+      aLocationBits.forEach(function (aBit) {
+        trimmedBit = aBit.trim();
+        if (!filteredLocations.includes(trimmedBit) && isOK(trimmedBit)) filteredLocations.push(trimmedBit);
+      });
+    }
+  });
+  const suggestedMatches = [];
+  let aMatch, aLink, aText, aLocation, aLocations, dateMatch;
+  $("tr[id^=potentialMatch] td:first-child").each(function () {
+    aMatch = {};
+    aLink = $(this).find("a").eq(0);
+    aMatch.WTID = aLink.attr("href").split("wiki/")[1];
+    aMatch.name = aLink.text();
+    aMatch.locations = [];
+    aText = $(this).text().split(" - ");
+    if (aText[1]) {
+      dateMatch = aText[1].match(/.*\s[0-9]{4}s?/);
+      if (dateMatch) {
+        aMatch.DeathDate = dateMatch[0].trim();
+      }
+    }
+    aLocation = aText[0].split(/[0-9]{4}s?/)[1].trim();
+    dateMatch = aText[0].match(/.*[0-9]{4}s?/);
+    if (dateMatch) {
+      aMatch.BirthDate = dateMatch[0];
+    }
+    aLocations = aLocation.split(",");
+    aLocations.forEach(function (aLocation) {
+      aMatch.locations.push(aLocation.trim());
+    });
+    suggestedMatches.push(aMatch);
+  });
+  console.log(filteredLocations);
+  console.log(suggestedMatches);
+
+  const filterButtons = $(
+    "<div id='filterButtons'><label>Filters: </label><button class='small button' id='locationFilterButton'>Location</button></div>"
+  );
+  if ($("#filterButtons").length == 0) {
+    filterButtons.appendTo($("#matchesStatusBox p.large"));
+  }
+  $("#locationFilterButton").on("click", function (e) {
+    e.preventDefault();
+    if ($(this).attr("data-level") == "2") {
+      $(this).attr("data-level", "0");
+      $(this).text("location");
+      $(".locationFiltered").removeClass("locationFiltered");
+    } else {
+      if ($(this).attr("data-level") == "1") {
+        $(this).attr("data-level", "2");
+        $(this).text("location 2");
+      } else {
+        $(this).attr("data-level", "1");
+        $(this).text("location 1");
+      }
+
+      suggestedMatches.forEach(function (person) {
+        let thisTR = $("a[href$='" + person.WTID + "']").closest("tr");
+        let matchCount = 0;
+        person.locations.forEach(function (aLocation) {
+          if (filteredLocations.includes(aLocation)) {
+            if (!countries.includes(aLocation)) {
+              matchCount++;
+            }
+            if ($("#locationFilterButton").attr("data-level") != "2") {
+              matchCount++;
+            }
+          }
+        });
+        if (matchCount == 0) {
+          thisTR.addClass("locationFiltered");
+        }
+        if (matchCount > 2) {
+          thisTR.prependTo(thisTR.parent());
+        }
+        if (newPerson.locations.length) {
+          if (person.locations.includes(newPerson.locations[0])) {
+            thisTR.prependTo(thisTR.parent());
+          }
+        }
+      });
+    }
+  });
+}
+
+const countries = [
+  "Afghanistan",
+  "Albania",
+  "Algeria",
+  "American Samoa",
+  "Andorra",
+  "Angola",
+  "Anguilla",
+  "Antarctica",
+  "Antigua and Barbuda",
+  "Argentina",
+  "Armenia",
+  "Aruba",
+  "Australia",
+  "Austria",
+  "Azerbaijan",
+  "Bahamas",
+  "Bahrain",
+  "Bangladesh",
+  "Barbados",
+  "Belarus",
+  "Belgium",
+  "Belize",
+  "Benin",
+  "Bermuda",
+  "Bhutan",
+  "Bolivia",
+  "Bonaire, Sint Eustatius and Saba",
+  "Bosnia and Herzegovina",
+  "Botswana",
+  "Bouvet Island",
+  "Brazil",
+  "British Indian Ocean Territory",
+  "Brunei Darussalam",
+  "Bulgaria",
+  "Burkina Faso",
+  "Burundi",
+  "Cabo Verde",
+  "Cambodia",
+  "Cameroon",
+  "Canada",
+  "Cayman Islands",
+  "Central African Republic",
+  "Chad",
+  "Chile",
+  "China",
+  "Christmas Island",
+  "Cocos (Keeling) Islands",
+  "Colombia",
+  "Comoros",
+  "Democratic Republic of the Congo",
+  "Congo",
+  "Cook Islands",
+  "Costa Rica",
+  "Croatia",
+  "Cuba",
+  "Curaçao",
+  "Cyprus",
+  "Czechia",
+  "Côte d'Ivoire",
+  "Denmark",
+  "Djibouti",
+  "Dominica",
+  "Dominican Republic",
+  "Ecuador",
+  "Egypt",
+  "El Salvador",
+  "Equatorial Guinea",
+  "Eritrea",
+  "Estonia",
+  "Eswatini",
+  "Ethiopia",
+  "Falkland Islands",
+  "Faroe Islands",
+  "Fiji",
+  "Finland",
+  "France",
+  "French Guiana",
+  "French Polynesia",
+  "French Southern Territories",
+  "Gabon",
+  "Gambia",
+  "Georgia",
+  "Germany",
+  "Ghana",
+  "Gibraltar",
+  "Greece",
+  "Greenland",
+  "Grenada",
+  "Guadeloupe",
+  "Guam",
+  "Guatemala",
+  "Guernsey",
+  "Guinea",
+  "Guinea-Bissau",
+  "Guyana",
+  "Haiti",
+  "Heard Island and McDonald Islands",
+  "Holy See",
+  "Honduras",
+  "Hong Kong",
+  "Hungary",
+  "Iceland",
+  "India",
+  "Indonesia",
+  "Iran",
+  "Iraq",
+  "Ireland",
+  "Isle of Man",
+  "Israel",
+  "Italy",
+  "Jamaica",
+  "Japan",
+  "Jersey",
+  "Jordan",
+  "Kazakhstan",
+  "Kenya",
+  "Kiribati",
+  "Korea",
+  "North Korea",
+  "Korea",
+  "South Korea",
+  "Kuwait",
+  "Kyrgyzstan",
+  "Laos",
+  "Lao People's Democratic Republic",
+  "Latvia",
+  "Lebanon",
+  "Lesotho",
+  "Liberia",
+  "Libya",
+  "Liechtenstein",
+  "Lithuania",
+  "Luxembourg",
+  "Macao",
+  "Madagascar",
+  "Malawi",
+  "Malaysia",
+  "Maldives",
+  "Mali",
+  "Malta",
+  "Marshall Islands",
+  "Martinique",
+  "Mauritania",
+  "Mauritius",
+  "Mayotte",
+  "Mexico",
+  "Micronesia",
+  "Moldova",
+  "Monaco",
+  "Mongolia",
+  "Montenegro",
+  "Montserrat",
+  "Morocco",
+  "Mozambique",
+  "Myanmar",
+  "Namibia",
+  "Nauru",
+  "Nepal",
+  "Netherlands",
+  "New Caledonia",
+  "New Zealand",
+  "Nicaragua",
+  "Niger",
+  "Nigeria",
+  "Niue",
+  "Norfolk Island",
+  "Northern Mariana Islands",
+  "Norway",
+  "Oman",
+  "Pakistan",
+  "Palau",
+  "Palestine",
+  "Panama",
+  "Papua New Guinea",
+  "Paraguay",
+  "Peru",
+  "Philippines",
+  "Pitcairn",
+  "Poland",
+  "Portugal",
+  "Puerto Rico",
+  "Qatar",
+  "Republic of North Macedonia",
+  "Romania",
+  "Russian Federation",
+  "Russia",
+  "Soviet Union",
+  "USSR",
+  "Rwanda",
+  "Réunion",
+  "Saint Barthélemy",
+  "Saint Helena, Ascension and Tristan da Cunha",
+  "Saint Kitts and Nevis",
+  "Saint Lucia",
+  "Saint Martin",
+  "Saint Pierre and Miquelon",
+  "Saint Vincent and the Grenadines",
+  "Samoa",
+  "San Marino",
+  "Sao Tome and Principe",
+  "Saudi Arabia",
+  "Senegal",
+  "Serbia",
+  "Seychelles",
+  "Sierra Leone",
+  "Singapore",
+  "Sint Maarten",
+  "Slovakia",
+  "Slovenia",
+  "Solomon Islands",
+  "Somalia",
+  "South Africa",
+  "South Georgia and the South Sandwich Islands",
+  "South Sudan",
+  "Spain",
+  "Sri Lanka",
+  "Sudan",
+  "Suriname",
+  "Svalbard and Jan Mayen",
+  "Sweden",
+  "Switzerland",
+  "Syrian Arab Republic",
+  "Taiwan",
+  "Tajikistan",
+  "Tanzania",
+  "Thailand",
+  "Timor-Leste",
+  "Togo",
+  "Tokelau",
+  "Tonga",
+  "Trinidad and Tobago",
+  "Tunisia",
+  "Turkey",
+  "Turkmenistan",
+  "Turks and Caicos Islands",
+  "Tuvalu",
+  "Uganda",
+  "Ukraine",
+  "United Arab Emirates",
+  "UAE",
+  "United Kingdom of Great Britain and Northern Ireland",
+  "United Kingdom",
+  "UK",
+  "Great Britain",
+  "England",
+  "Scotland",
+  "Wales",
+  "United States of America",
+  "United States",
+  "USA",
+  "US",
+  "Uruguay",
+  "Uzbekistan",
+  "Vanuatu",
+  "Venezuela",
+  "Viet Nam",
+  "Virgin Islands",
+  "Virgin Islands",
+  "Wallis and Futuna",
+  "Western Sahara",
+  "Yemen",
+  "Zambia",
+  "Zimbabwe",
+  "Åland Islands",
+  "日本",
+  "Sverige",
+  "Guåhan",
+  "الجزائر",
+  "Монгол Улс",
+  "پاکستان",
+  "சிங்கப்பூர்",
+  "Ködörösêse tî Bêafrîka",
+  "Guiné-Bissau",
+  "Polska",
+  "Serra Leoa",
+  "Slovensko",
+  "Mauritanie",
+  "Kūki 'Āirani",
+  "Maurice",
+  "As-Sūmāl",
+  "Viti",
+  "ގުޖޭއްރާ ޔާއްރިހޫމްޖު",
+  "מדינת ישראל",
+  "Беларусь",
+  "Ελλάδα",
+  "ශ්‍රී ලංකාව",
+  "Bosna i Hercegovina",
+  "تونس",
+  "საქართველო",
+  "България",
+  "فلسطین",
+  "España",
+  "Kamerun",
+  "Suomi",
+  "لبنان",
+  "Senegal",
+  "چین",
+  "Francia",
+  "פרטי השטח של הוותיקן",
+  "Gambia",
+  "Svizzera",
+  "Italia",
+  "مصر",
+  "Российская Федерация",
+  "Deutschland",
+  "Guinea Ecuatorial",
+  "Estado Plurinacional de Bolivia",
+  "Казахстан",
+  "Moldova",
+  "Србија",
+  "Україна",
+  "Hrvatska",
+  "കൊറിയ",
+  "नेपाल",
+  "Nederland",
+  "Verenigde Staten",
+  "Omán",
+  "المغرب",
+  "جزر العرب المتحدة",
+  "République Démocratique du Congo",
+  "Eesti",
+  "Lietuva",
+  "قطر",
+  "Magyarország",
+  "العراق",
+  "Island",
+  "Îles Marshall",
+  "México",
+  "Türkiye",
+  "Maldives",
+  "Mozambique",
+  "Namibia",
+  "Nauru",
+  "Nepal",
+  "Nicaragua",
+  "Niger",
+  "Nigeria",
+  "Niue",
+  "Norfolk Island",
+  "Norvegia",
+  "Nouvelle-Calédonie",
+  "Nouvelle-Zélande",
+  "Oman",
+  "Pakistan",
+  "Palaos",
+  "Panama",
+  "Papouasie-Nouvelle-Guinée",
+  "Paraguay",
+  "Pays-Bas",
+  "Perú",
+  "Philippines",
+  "Pitcairn",
+  "Pologne",
+  "Polynésie française",
+  "Portugal",
+  "Qatar",
+  "République centrafricaine",
+  "République dominicaine",
+  "République tchèque",
+  "Roumanie",
+  "Royaume-Uni",
+  "Russie",
+  "Rwanda",
+  "Sahara occidental",
+  "Saint-Barthélemy",
+  "Saint-Kitts-et-Nevis",
+  "Saint-Martin",
+  "Saint-Vincent-et-les Grenadines",
+  "Samoa",
+  "Samoa américaines",
+  "São Tomé-et-Príncipe",
+  "Sénégal",
+  "Serbie",
+  "Seychelles",
+  "Sierra Leone",
+  "Singapour",
+  "Slovaquie",
+  "Slovénie",
+  "Somalie",
+  "Soudan",
+  "Sri Lanka",
+  "Suède",
+  "Suisse",
+  "Suriname",
+  "Svalbard et Île Jan Mayen",
+  "Swaziland",
+  "Syrie",
+  "Tadjikistan",
+  "Taïwan",
+  "Tanzanie",
+  "Tchad",
+  "Terres australes françaises",
+  "Thaïlande",
+  "Timor oriental",
+  "Togo",
+  "Tokelau",
+  "Tonga",
+  "Trinité-et-Tobago",
+  "Tunisie",
+  "Turkménistan",
+  "Turques et Caïques",
+  "Tuvalu",
+  "Ukraine",
+  "Uruguay",
+  "Vanuatu",
+  "Venezuela",
+  "Viêt Nam",
+  "Wallis-et-Futuna",
+  "Yémen",
+  "Zambie",
+  "Zimbabwe",
+];

--- a/src/features/suggested_matches_filters/suggested_matches_filters.js
+++ b/src/features/suggested_matches_filters/suggested_matches_filters.js
@@ -33,10 +33,10 @@ function addNewPersonToH1() {
     newPerson.FirstName +
     " " +
     (newPerson.MiddleName ? newPerson.MiddleName + " " : "") +
-    (newPerson.LastNameCurrent && newPerson.LastNameCurrent != newPerson.LastNameAtBirth
+    (isOK(newPerson.LastNameCurrent) && newPerson.LastNameCurrent != newPerson.LastNameAtBirth
       ? "(" + newPerson.LastNameAtBirth + ") " + ""
       : "") +
-    newPerson.LastNameCurrent +
+    (isOK(newPerson.LastNameCurrent) ? newPerson.LastNameCurrent : newPerson.LastNameAtBirth) +
     " " +
     "(" +
     newPerson.BirthYear +

--- a/src/features/suggested_matches_filters/suggested_matches_filters.js
+++ b/src/features/suggested_matches_filters/suggested_matches_filters.js
@@ -51,17 +51,20 @@ function addNewPersonToH1() {
 checkIfFeatureEnabled("suggestedMatchesFilters").then((result) => {
   if (result && $("body.page-Special_EditFamilySteps")) {
     $("#enterBasicDataButton").on("click", function () {
-      checkReady();
+      setTimeout(function () {
+        checkReady();
+      }, 1000);
       addNewPersonToH1();
     });
   }
 });
-
+var checked = 0;
 function checkReady() {
   if ($("#potentialMatchesSection table").length) {
     initSuggestedMatchesFilters();
-  } else {
+  } else if (checked < 10) {
     setTimeout(function () {
+      checked++;
       checkReady();
     }, 1000);
   }

--- a/src/features/suggested_matches_filters/suggested_matches_filters.js
+++ b/src/features/suggested_matches_filters/suggested_matches_filters.js
@@ -168,7 +168,7 @@ async function nameFilter(level) {
       person.FirstName = thisPerson.FirstName;
       person.MiddleName = thisPerson.MiddleName;
     }
-    let thisTR = $("a[href$='" + person.WTID + "']").closest("tr");
+    let thisTR = $(`a[href\$="${person.WTID}"]`).closest("tr");
     if ($("#mStatus_MiddleName_blank").prop("checked") == true) {
       if (person.MiddleName) {
         thisTR.addClass("nameFiltered");


### PR DESCRIPTION
Adds filter buttons to the suggested matches table on the new profile creation page.
Location 1 (Click 'Location' once): Checks location words of new person and their family members against the locations of each suggested match. Also moves better matches to the top of the list.
Location 2 (Click 'Location' again): The same as location 1, but ignores the country.
Name 1 (Click 'Name' once): Filters on the middle name.
Name 2 (Click 'Name' again): Matches only exact names.
Date 1: Narrows the list down to people born up to two years before or after the new person.
Date 2: One year before or after the new person.
Date 3: The same year as the new person.