### PR TITLE
Options: Restore 'All'; add 'Default;

### DIFF
--- a/public/main.css
+++ b/public/main.css
@@ -183,6 +183,23 @@ input:checked + .slider:before {
   border: 2px solid gray;
 }
 
+h1 .feature-toggle {
+  margin-left: 0.5em;
+}
+h1 #default {
+  float: right;
+  position: relative;
+  display: inline-block;
+  width: 60px;
+  height: 34px;
+  border-radius: 34px;
+  border: 0;
+  font-weight: bold;
+}
+h1 #default:active {
+  box-shadow: 0;
+}
+
 /* content */
 #wte-topMenuUL {
   margin-right: 1em;


### PR DESCRIPTION
+ Remove Dark Mode from 'All'
+ Make the category header switches reflect the state of the switches (if one is off, the header switch should be off; if they're all on, the header switch should be on)
