### PR TITLE
Improve wording in relationship feature

### DIFF
--- a/src/features/distanceAndRelationship/distanceAndRelationship.js
+++ b/src/features/distanceAndRelationship/distanceAndRelationship.js
@@ -228,13 +228,14 @@ function commonAncestorText(commonAncestors) {
   }
   let ancestorsAdded = [];
   commonAncestors.forEach(function (commonAncestor) {
+    const myAncestorType = ancestorType(commonAncestor.path1Length - 1, commonAncestor.ancestor.mGender).toLowerCase();
     const thisAncestorType = ancestorType(
       commonAncestor.path2Length - 1,
       commonAncestor.ancestor.mGender
     ).toLowerCase();
     if (!ancestorsAdded.includes(commonAncestor.ancestor.mName)) {
       ancestorTextOut +=
-        '<li>Your common ancestor, <a href="https://www.wikitree.com/wiki/' +
+        `<li>Your ${myAncestorType}, <a href="https://www.wikitree.com/wiki/` +
         commonAncestor.ancestor.mName +
         '">' +
         commonAncestor.ancestor.mDerived.LongNameWithDates +


### PR DESCRIPTION
The wordig "Your common ancestor, XYZ, is <his/her/their> <relation>" is changed to "Your <relation> YXZ, is <his/her/their> <relation>", e.g "Your 6th great-grandfather, Johannes Franke (1686-1743), is his 2nd great-grandfather"