### PR TITLE
New features: Accessibility Options and Reading Mode

### DIFF
--- a/src/content.js
+++ b/src/content.js
@@ -3,6 +3,7 @@
 import "./features/register_feature_options";
 
 import "./features/access_keys/access_keys";
+import "./features/accessibility/accessibility";
 import "./features/agc/agc_content";
 import "./features/akaNameLinks/akaNameLinks";
 import "./features/appsMenu/appsMenu";
@@ -32,6 +33,7 @@ import "./features/my_connections/my_connections";
 import "./features/my_menu/my_menu";
 import "./features/printerfriendly/printerfriendly";
 import "./features/randomProfile/randomProfile";
+import "./features/readingMode/readingMode";
 import "./features/redir_ext_links/redir_ext_links";
 import "./features/scissors/scissors";
 import "./features/sortBadges/sortBadges";
@@ -43,6 +45,12 @@ import "./features/suggested_matches_filters/suggested_matches_filters";
 import "./features/verifyID/verifyID";
 import "./features/what_links_here/what_links_here";
 import "./features/wtPlus/wtPlus";
+
+/*
+ * debugging features for development only
+ *
+import "./features/debugProfileClasses/debugProfileClasses";
+// end debugging section */
 
 import "./core/editToolbar";
 

--- a/src/core/profileClasses.js
+++ b/src/core/profileClasses.js
@@ -1,0 +1,110 @@
+import $ from "jquery";
+import { pageProfile, pageCategory, pageSpace, isEditPage } from './common';
+
+export let hasProfileClasses = false;
+
+export function canTweakProfile() {
+  return (!isEditPage && (pageProfile || pageCategory || pageSpace));
+}
+
+export function ensureProfileClasses() {
+  // only apply once per load by tracking the status in hasProfileClasses
+  if (!hasProfileClasses) {
+    // only apply to person, category, and space profiles in read mode
+    if (canTweakProfile()) {
+      // at the moment, WikiTree puts two different elements with id="content" on person pages (the heading and tabs are separate from the rest of the profile)
+      $("div[id='content']").addClass("x-profile").addClass(pageProfile ? "x-profile-person" : pageCategory ? "x-profile-category" : pageSpace ? "x-profile-space" : "");
+
+      // mark the heading content (the h1 beside the thumbnail image and the privacy status, which includes the scissors inside) *** varies by profile type
+      $(".x-profile-person > .row h1, .x-profile-space > .row h1").first().addClass("x-heading-title");
+      $(".x-heading-title").closest(".row").addClass("x-heading");
+      $(".x-profile-category > .sixteen.columns h1").first().addClass("x-heading x-heading-title");
+
+      // mark the thumbnail image container based on the heading
+      $(".x-heading > .alpha").first().addClass("x-thumbnail");
+
+      // mark the widgets (including the scissors container) inside the h1 tag
+      $(".x-heading-title button").addClass("x-heading-widget");
+      $(".x-profile-category .x-heading").prevAll().filter(function () { return $(this).css("float") == "right" && $(this).has("a, button"); }).addClass("x-heading-widget");
+      $(function () {
+        // some extensions add these differently based on the type of profile, so we need to reapply these after the page is loaded and other extensions have made their updates
+        window.setTimeout(function () {
+          // .copyWidget seems mostly standard, but other extensions put their widgets in identified span tags (helpScissors, distanceFromYou, yourRelationshipText, etc.)
+          $(".x-heading-title button, .copyWidget, .x-heading-title span[id], .x-heading-title:not(.x-heading) ~ *[id]").addClass("x-heading-widget");
+        }, 500);
+      });
+
+      // mark the privacy status container at the right of the heading
+      $(".x-heading a.nohover").parent().addClass("x-privacy");
+
+      // mark the content section (on the left of the sidebar) which contains the biography, sources, etc. up to where the comments section starts; for categories, the content is all in the root section
+      $(".x-profile > .ten.columns, .x-profile-category > .columns").first().addClass("x-content");
+
+      // mark alert boxes (like research notes, orphaned profile, etc.)
+      $("x-content > .status, .x-content > a[name]:last-of-type ~ .box.orange, .x-content:not(* > a[name]) > .box.orange").addClass("x-alert");
+
+      // mark the sidebar to the right (with DNA connections, images, collaboration, etc.)
+      $(".x-profile > .six.columns").first().addClass("x-sidebar");
+
+      // mark the tabs, including the main tabs at the top (which link to different pages) and the buttons below them (which jump to different views)
+      $(".x-profile .profile-tabs").addClass("x-tabs-page");
+      $(".x-profile #views-wrap").addClass("x-tabs-view");
+      $(".x-tabs-page, .x-tabs-view").first().closest(".columns").addClass("x-tabs"); // this includes the div containing both sets of tabs
+
+      // mark any kind of edit links or buttons like [edit], [add spouse], Invite Others, etc.
+      $(".x-content div.EDIT, .x-content a.BLANK, .x-content .editsection, .x-content a[href$='#additions']").addClass("x-edit");
+
+      // mark the audit lines in the profile that show the manager, last modified, how many times the page has been accessed, etc.
+      $(".x-content > div.SMALL").addClass("x-audit");
+      $(".x-content p.SMALL").filter(function () { var txt = $(this).text(); return (txt.indexOf('last modified') > -1 && txt.indexOf('been accessed') > -1); }).addClass("x-audit"); // category pages are displayed this way
+
+      // mark the sources link in the table of contents
+      $("#toc a[href='#Sources']").closest("li").addClass("x-toc-sources");
+
+      // mark stickers inside the content
+      $(".x-content > div").filter(function () { return $(this).css("float") == "right" && $(this).css("display") == "flex"; }).addClass("x-sticker");
+
+      // mark inline citations (both <ref> tags and "citation needed")
+      $(".x-content sup.reference, .x-content sup > i > a[href$='/Help:Sources']").closest("sup").addClass("x-citation");
+
+      // mark inline images
+      $(".x-content table").has("a.image > img").addClass("x-inline-img");
+
+      // mark inline tables (inline images must be marked first so that they will be excluded, along with the table of contents)
+      $(".x-content table:not(#toc):not(.x-inline-img)").addClass("x-inline-table");
+
+      // mark root sections in content (h2 only)
+      $(".x-content a[name] + h1, .x-content a[name] + h2").prev().addClass("x-root-section x-section");
+
+      // mark subdivided sections (h3, etc.)
+      $(".x-content a[name] + h3, .x-content a[name] + h4, .x-content a[name] + h5, .x-content a[name] + h6").prev().addClass("x-section");
+
+      // mark memories section (only at the bottom of certain profiles)
+      $("a[name='Memories']").prev().addClass("x-memories").nextAll().addClass("x-memories");
+      $(".x-memories, .x-content > br:last-child").addClass("x-memories").prevUntil("*:not(br)").addClass("x-memories"); // memories are usually preceded by a couple of line breaks, sometimes present at the end of content even if the memories block is missing
+
+      // mark elements related to the sources section (including header, lists, and any other root elements) up until the next section *** dependent on x-memories being set
+      $(".x-content a[name='Sources']").first().addClass("x-sources").nextUntil(".x-root-section, div.EDIT, .x-memories, br[clear] + div.SMALL").addClass("x-sources");
+      $(".x-content ol.references").addClass("x-sources");
+      // mark source list items separately
+      $("ul.x-sources > li, ol.x-sources > li").addClass("x-src");
+
+      // mark comments section, including the form components
+      $("#comments, .comment-form-container").addClass("x-comments");
+
+      // mark merges section, including pending and rejected matches
+      $(".x-profile-person a[name='matches']").parent().addClass("x-merges").nextAll(".five").addClass("x-merges");
+
+      // mark connections to famous people
+      $(".x-profile-person > div:last-child").filter(function () { return $(this).text().indexOf('degrees from') > -1 && $(this).has("a[href~='Special:Connect']"); }).last().addClass("x-connections");
+
+      // mark the container for the categories box, including the breadcrumbs at the bottom of profiles (ie. S > Smith > John Smith) and the top of the category profile
+      $(".x-profile-category .x-content > p > a:first-of-type[href$='/Category:Categories']").parent().addClass("x-categories");
+      $("#categories").closest(".container").addClass("x-categories");
+      $("#footer").prev().addClass("x-categories");
+
+      // prevent this from running more than once per page
+      hasProfileClasses = true;
+    }
+  }
+}

--- a/src/core/toggleCheckbox.css
+++ b/src/core/toggleCheckbox.css
@@ -1,0 +1,49 @@
+/* turns a checkbox input into a toggle button */
+.toggle input[type='checkbox'] {
+  display: none;
+}
+
+.toggle input[type='checkbox'] + label {
+  position: relative;
+  margin-left: 55px;
+  line-height: 24px;
+  font-size: 15px;
+}
+
+.toggle input[type='checkbox'] + label::before {
+  content: ' ';
+  display: block;
+  position: absolute;
+  top: -3px;
+  left: -55px;
+  width: 45px;
+  height: 24px;
+  background-color: #ddd;
+  border: 1px solid #d3d3d5;
+  border-radius: 13px;
+  box-shadow: 0 0px 3px rgba(0, 0, 0, 0.1);
+  transition: background-color 0.4s ease;
+}
+
+.toggle input[type='checkbox'] + label::after {
+  content: ' ';
+  display: block;
+  position: absolute;
+  top: -1px;
+  left: -53px;
+  width: 20px;
+  height: 20px;
+  background-color: #fff;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.2);
+  border: 1px solid #d3d3d5;
+  border-radius: 11px;
+  transition: left 0.4s ease;
+}
+
+.toggle input[type='checkbox']:checked + label::before {
+  background-color: #8fc641;
+}
+
+.toggle input[type='checkbox']:checked + label::after {
+  left: -32px;
+}

--- a/src/features/accessibility/accessibility.css
+++ b/src/features/accessibility/accessibility.css
@@ -1,0 +1,19 @@
+:root {
+  --a11y-spacing: 1em;
+}
+
+.a11y-list-spacing .x-content > ol > li,
+.a11y-list-spacing .x-content > ul > li {
+  margin-top: var(--a11y-spacing);
+  margin-bottom: var(--a11y-spacing);
+}
+
+.a11y-src-spacing ol.x-sources > li,
+.a11y-src-spacing ul.x-sources > li {
+  margin-top: var(--a11y-spacing);
+  margin-bottom: var(--a11y-spacing);
+}
+
+.a11y-src-bold .a11y-src-first {
+  font-weight: bold;
+}

--- a/src/features/accessibility/accessibility.js
+++ b/src/features/accessibility/accessibility.js
@@ -1,0 +1,142 @@
+import $ from "jquery";
+import { checkIfFeatureEnabled, getFeatureOptions } from "../../core/options/options_storage.js";
+import { ensureProfileClasses, canTweakProfile } from "../../core/profileClasses";
+
+async function initAccessibility() {
+  ensureProfileClasses();
+  const options = await getFeatureOptions("accessibility");
+  if (options.listItemSpacing && options.listItemSpacing > 0) {
+    document.documentElement.style.setProperty("--a11y-spacing", 1.5 * options.listItemSpacing / 100 + "em"); // this is based on the normal paragraph margin being 1.5em
+    if (options.spaceSourceItemsOnly) {
+      $("html").addClass("a11y-src-spacing"); // only apply spacing to lists in the Sources section
+    } else {
+      $("html").addClass("a11y-list-spacing"); // apply spacing rules to all lists in the profile content
+    }
+  }
+  if (options.mergeAdjacentLists) {
+    let qy;
+    if (options.spaceSourceItemsOnly) {
+      qy = $(".x-content > .x-sources"); // only look at elements in the Sources section
+    } else {
+      qy = $(".x-content > *:not(#toc)").first().nextAll(); // look at all elements at the root of the content section (except for the TOC)
+    }
+    let ul;
+    qy.each(function (index) {
+      let el = $(this);
+      if (el.is("ul")) {
+        if (ul) {
+          let li = el.children().detach().appendTo(ul); // merge all child list items into the preceding list
+          el.remove();
+        } else {
+          ul = el; // this will be the starting point where all successive lists will be merged into
+        }
+      } else {
+        ul = null; // there are no more adjacent lists, so start looking for the next starting point
+      }
+    });
+  }
+  if (options.removeSourceBreaks || options.removeSourceLabels || options.boldSources) {
+    let qy = $(".x-src");
+    if (options.removeSourceBreaks) {
+      qy.each(function (index) {
+        let li = $(this);
+        let isFirst = true;
+        li.find("br").replaceWith(" ");
+      });
+    }
+    if (options.removeSourceLabels) {
+      qy.each(function (index) {
+        let li = $(this);
+        let isFirst = true;
+        li.contents().each(function () {
+          let el = $(this);
+          if (el.is("sup, a[href^='#'], span:empty")) {
+            return true; // skip over back-reference links
+          }
+          if (this.nodeValue && /^\u2191?\s*$/.test(this.nodeValue)) {
+            return true; // skip over whitespace and the up arrow (sometimes a link, sometimes text, depending on whether there are multiple references)
+          }
+          if (el.is("b")) {
+            if (this.nextSibling && this.nextSibling.nodeType && this.nextSibling.nodeType === 3) {
+              this.nextSibling.nodeValue = this.nextSibling.nodeValue.replace(/^[\s:;,.-]+/, "");
+            }
+            el.remove();
+          }
+          return false;
+        });
+      });
+    }
+    if (options.boldSources) {
+      $("html").addClass("a11y-src-bold");
+      qy.each(function (index) {
+        let li = $(this);
+        let state = 1;
+        li.contents().filter(function () {
+          let el = $(this);
+          if (state > 3) {
+            return false;
+          } else if (state == 1) {
+            // skip back-references, anchors, whitespace, and the up arrow (sometimes a link, sometimes text, depending on whether there are multiple references) at the beginning
+            if (el.is("sup, a[href^='#'], span:empty") || (this.nodeValue && /^\u2191?\s*$/.test(this.nodeValue))) {
+              return false;
+            }
+            state++;
+          }
+          if (this.nodeType) {
+            if (state == 2 && this.nodeType == 1 && $(this).is("i, b, a")) {
+              state++;
+              return true;
+            } else if (this.nodeType == 3 && state <= 3) {
+              if (/\S/.test(this.textContent)) {
+                state = 4;
+                return true;
+              }
+            }
+          }
+          return false;
+        }).each(function () {
+          if (this.nodeType == 3) {
+            let match;
+            if (state < 5) {
+              let first, rest;
+              if (match = (this.textContent.match(/^(\s*["\u201c-\u201d].{6,100}?["\u201c-\u201d]+)(.*)/))) {
+                // for sources that start with something enclosed in quotes
+                rest = match[2];
+                first = match[1];
+              } else if (match = (this.textContent.match(/^((\s*[^"\u2018-\u201d,]{4,20}\w*,){1,2}[^"\u2018-\u201d,.]{4,20}\w*[,.]\s*)(.*)/))) {
+                // for sources with comma separators such as Last, First Middle, Jr.
+                rest = match[3];
+                first = match[1];
+              } else if (match = (this.textContent.match(/^(\s*[^"\u201c-\u201d]{3,20}\w*\b[^"\u201c-\u201d,.(]{0,20}\w*[,.)]*)(.*)/))) {
+                // for sources that start with some other non-quoted phrase that terminates with a separator
+                rest = match[2];
+                first = match[1];
+                if (match = (first.match(/(.*(\w{1,4}\.\s*){2,}\s+\b(\w+\.)?)(.*)/))) {
+                  // special case for Smith, John, Ph.D. or Smith, Lt. Col. Samuel.
+                  first = match[1];
+                  rest = match[4] + rest;
+                }
+              }
+              // only update if there would be some content after the bold text
+              if (/\S/.test(rest || "") || $(this).nextAll().length > 0) {
+                this.textContent = rest;
+                let segment = $('<span class="a11y-src-first"></span>');
+                segment.text(first).insertBefore(this);
+              }
+            }
+          } else if (state > 3) { // if it's only a standalone link, don't bold the whole thing
+            $(this).wrap('<span class="a11y-src-first"></span>');
+            state = 5;
+          }
+        });
+      });
+    }
+  }
+}
+
+checkIfFeatureEnabled("accessibility").then((result) => {
+  if (result && canTweakProfile()) {
+    import("./accessibility.css");
+    initAccessibility();
+  }
+});

--- a/src/features/accessibility/accessibility.js
+++ b/src/features/accessibility/accessibility.js
@@ -99,19 +99,19 @@ async function initAccessibility() {
             let match;
             if (state < 5) {
               let first, rest;
-              if (match = (this.textContent.match(/^(\s*["\u201c-\u201d].{6,100}?["\u201c-\u201d]+)(.*)/))) {
+              if (match = (this.textContent.match(/^(\s*["\u201c-\u201d].{6,100}?["\u201c-\u201d]+)(.*)/s))) {
                 // for sources that start with something enclosed in quotes
                 rest = match[2];
                 first = match[1];
-              } else if (match = (this.textContent.match(/^((\s*[^"\u2018-\u201d,]{4,20}\w*,){1,2}[^"\u2018-\u201d,.]{4,20}\w*[,.]\s*)(.*)/))) {
+              } else if (match = (this.textContent.match(/^((\s*[^"\u2018-\u201d,]{4,20}\w*,){1,2}[^"\u2018-\u201d,.]{4,20}\w*[,.]\s*)(.*)/s))) {
                 // for sources with comma separators such as Last, First Middle, Jr.
                 rest = match[3];
                 first = match[1];
-              } else if (match = (this.textContent.match(/^(\s*[^"\u201c-\u201d]{3,20}\w*\b[^"\u201c-\u201d,.(]{0,20}\w*[,.)]*)(.*)/))) {
+              } else if (match = (this.textContent.match(/^(\s*[^"\u201c-\u201d]{3,20}\w*\b[^"\u201c-\u201d,.(]{0,20}\w*[,.)]*)(.*)/s))) {
                 // for sources that start with some other non-quoted phrase that terminates with a separator
                 rest = match[2];
                 first = match[1];
-                if (match = (first.match(/(.*(\w{1,4}\.\s*){2,}\s+\b(\w+\.)?)(.*)/))) {
+                if (match = (first.match(/(.*(\w{1,4}\.\s*){2,}\s+\b(\w+\.)?)(.*)/s))) {
                   // special case for Smith, John, Ph.D. or Smith, Lt. Col. Samuel.
                   first = match[1];
                   rest = match[4] + rest;

--- a/src/features/accessibility/accessibility_options.js
+++ b/src/features/accessibility/accessibility_options.js
@@ -1,0 +1,83 @@
+import { registerFeature, OptionType } from "../../core/options/options_registry";
+
+const accessibilityFeature = {
+  name: "Accessibility Options",
+  id: "accessibility",
+  description: "Display options to make profiles more readable for those with impaired vision.",
+  category: "Style",
+  defaultValue: false,
+  options: [
+    {
+      id: "listItemSpacing",
+      type: OptionType.SELECT,
+      label: "The amount of spacing to add between list items",
+      values: [
+        {
+          value: 0,
+          text: "none",
+        },
+        {
+          value: 50,
+          text: "50% (half)",
+        },
+        {
+          value: 75,
+          text: "75%",
+        },
+        {
+          value: 100,
+          text: "100% (single)",
+        },
+        {
+          value: 150,
+          text: "150%",
+        },
+        {
+          value: 200,
+          text: "200% (double)",
+        },
+        {
+          value: 300,
+          text: "300%",
+        },
+        {
+          value: 400,
+          text: "400% (extra wide)",
+        },
+      ],
+      defaultValue: 100,
+    },
+    {
+      id: "mergeAdjacentLists",
+      type: OptionType.CHECKBOX,
+      label: "Remove extra line spacing (added by profile editors) from between adjacent bullet list items.",
+      defaultValue: false,
+    },
+    {
+      id: "spaceSourceItemsOnly",
+      type: OptionType.CHECKBOX,
+      label: "Limit spacing rules to only lists under the Sources section.",
+      defaultValue: true,
+    },
+    {
+      id: "boldSources",
+      type: OptionType.CHECKBOX,
+      label: "Bold the first segment of each source citation for readability.",
+      defaultValue: true,
+    },
+    {
+      id: "removeSourceBreaks",
+      type: OptionType.CHECKBOX,
+      label: "Remove extra line breaks (added by profile editors) from the middle of source citations.",
+      defaultValue: false,
+    },
+    {
+      id: "removeSourceLabels",
+      type: OptionType.CHECKBOX,
+      label: "Remove extra source labels (added by profile editors) from the beginning of source citations.",
+      defaultValue: false,
+    },
+  ],
+};
+
+registerFeature(accessibilityFeature);

--- a/src/features/debugProfileClasses/debugProfileClasses.css
+++ b/src/features/debugProfileClasses/debugProfileClasses.css
@@ -1,0 +1,169 @@
+/* already easily-identifiable elements */
+
+/* page-header */
+#header {
+  border-bottom: 5px solid #000 !important;
+  opacity: 0.5;
+}
+
+/* page-footer */
+#footer {
+  border-top: 5px solid #000 !important;
+  opacity: 0.5;
+}
+
+/* toc */
+#toc {
+  background: rgba(240,255,240,0.5) !important;
+}
+
+/* elements that need to be identified manually */
+
+.x-profile {
+  border: 3px dashed #999;
+}
+
+.x-content {
+  background: #ff9 !important;
+}
+
+.x-sidebar {
+  background: #9ab !important;
+}
+
+.x-heading {
+  background: #f98 !important;
+}
+
+.x-heading-title {
+  background: #fa9 !important;
+}
+
+.x-heading-widget {
+  background: #fcc !important;
+}
+
+.x-thumbnail {
+  background: #c99 !important;
+}
+
+.x-thumbnail img {
+  opacity: 0.5;
+}
+
+.x-privacy {
+  background: #e88 !important;
+}
+
+.x-privacy img {
+  opacity: 0.5;
+}
+
+.x-tabs {
+  background: #fec !important;
+}
+
+.x-tabs-page {
+  background: #fdc !important;
+}
+
+.x-tabs-view {
+  background: #ffc !important;
+}
+
+.x-edit {
+  background: #cb6 !important;
+}
+
+.x-audit {
+  background: #cf9 !important;
+}
+
+.x-alert {
+  border: 6px dotted #c00 !important;
+  opacity: 0.5;
+}
+
+.x-sticker {
+  background: #bcb !important;
+}
+
+.x-citation {
+  background: #ff0 !important;
+}
+
+.x-inline-img {
+  background: #444 !important;
+  opacity: 0.5;
+}
+
+.x-inline-img tr:last-child {
+  background: #cdc !important;
+}
+
+.x-inline-table {
+  background: #999 !important;
+  opacity: 0.5;
+}
+
+.x-section + h1, .x-section + h2, .x-section + h3, .x-section + h4, .x-section + h5, .x-section + h6 {
+  border-top: 1px dotted #876;
+}
+
+.x-root-section + h1 {
+  border-top: 5px solid #f00;
+}
+
+.x-root-section + h2 {
+  border-top-width: 5px;
+  border-top-style: solid;
+}
+
+.x-sources {
+  background: #8f9 !important;
+}
+
+.x-src {
+  background: #cfe !important;
+}
+
+.x-memories {
+  background: #9fc !important;
+}
+
+br.x-memories {
+  content: " ";
+  display: block;
+  background-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABQAAAAUCAYAAACNiR0NAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAEqSURBVDhP7ZM9TsMwGIbtUBOgIBYGkJgRIxMbd+AKTJyBC3AAxIgQaqfOHAIYOAEHYGZgQiU8b/w5TSoVxbQjr/To+3Hy2o4dtyIdgo/pH+W9LyweQUV6qXoZ1Ybo1AxfVKTmMppalOlKDDv6N6yl+7RmMVvzhjLRaenkFLNN24bKZRLgAvaszjJNhorfMXUjuIfzunJuADKdJ72rfCZuebsxAa1Kpn11Yn/KUyxnSmaPUMIm7MLOAjSmwzszw1eIojEmqPkFn5b3xgwfIO6fxlVVVdfKkX5yoRWk7/qbpryv3dzi8RxbaKMs7wia6Q0O1MsVxr5zKCGEEaVMP4j7sVtfI32rhfDsoO3j1kNo7mNRFDeMvcOxamIzlqXtrWEzA6ZDxc6sveTcD8GLO8c4hnhTAAAAAElFTkSuQmCC) !important;
+  width: 1.5em;
+  height: 1.5em;
+  border: 1px dashed #000;
+}
+
+.x-comments {
+  background: #9ff !important;
+}
+
+.x-comments .box {
+  background: #def !important;
+}
+
+.x-merges {
+  background: #9cf !important;
+}
+
+.x-connections {
+  background: #89f !important;
+}
+
+.x-connections > .box {
+  background: #acf !important;
+}
+
+.x-categories {
+  background: #c9f !important;
+}
+
+.x-categories #categories {
+  background: #ecf !important;
+}

--- a/src/features/debugProfileClasses/debugProfileClasses.js
+++ b/src/features/debugProfileClasses/debugProfileClasses.js
@@ -1,0 +1,9 @@
+import { ensureProfileClasses, canTweakProfile } from "../../core/profileClasses";
+import { checkIfFeatureEnabled } from "../../core/options/options_storage.js";
+
+checkIfFeatureEnabled("debugProfileClasses").then((result) => {
+  if (result && canTweakProfile()) {
+    import("./debugProfileClasses.css");
+    ensureProfileClasses();
+  }
+});

--- a/src/features/readingMode/readingMode.css
+++ b/src/features/readingMode/readingMode.css
@@ -1,0 +1,72 @@
+.toggle.reading-mode {
+  position: absolute;
+  right: 3px;
+  bottom: 12px;
+}
+
+.toggle.show-sources {
+  position: relative;
+  top: -2px;
+  margin-left: 8px;
+  visibility: hidden;
+}
+
+.collapse-sources .toggle.show-sources {
+  visibility: visible;
+}
+
+.hide-sidebar .x-sidebar {
+  display: none !important;
+}
+
+.collapse-sources:not(.expand-sources) .x-sources:not(h2):not(a[name]) {
+  display: none !important;
+}
+
+.hide-citations .x-citation {
+  display: none !important;
+}
+
+.hide-page-tabs .x-tabs-page {
+  display: none !important;
+}
+
+.hide-view-tabs .x-tabs-view {
+  display: none !important;
+}
+
+.hide-audit-data .x-audit {
+  display: none !important;
+}
+
+.hide-inline-images .x-inline-img {
+  display: none !important;
+}
+
+.hide-inline-tables .x-inline-table {
+  display: none !important;
+}
+
+.hide-comments .x-memories,
+.hide-comments .x-comments,
+.hide-comments .x-merges {
+  display: none !important;
+}
+
+.hide-heading-extras .x-heading-widget,
+.hide-heading-extras .x-privacy {
+  display: none !important;
+}
+
+.hide-edits .x-edit,
+.hide-edits .x-alert:not(.status) {
+  display: none !important;
+}
+
+.hide-connections .x-connections {
+  display: none !important;
+}
+
+.hide-categories .x-categories {
+  display: none !important;
+}

--- a/src/features/readingMode/readingMode.js
+++ b/src/features/readingMode/readingMode.js
@@ -1,0 +1,85 @@
+import $ from "jquery";
+import { checkIfFeatureEnabled, getFeatureOptions } from "../../core/options/options_storage.js";
+import { ensureProfileClasses, canTweakProfile } from "../../core/profileClasses";
+
+export let toggleReadingMode;
+
+async function initReadingMode() {
+  ensureProfileClasses();
+  const options = await getFeatureOptions("readingMode");
+  toggleReadingMode = function () {
+    if (options.hideSideBar) {
+      $("html").toggleClass("hide-sidebar");
+      $(".x-sidebar").prev().toggleClass("ten").toggleClass("sixteen");
+    }
+    if (options.hideInlineTables) {
+      $("html").toggleClass("hide-inline-tables");
+    }
+    if (options.collapseSources) {
+      $("html").toggleClass("collapse-sources");
+    }
+    if (options.hideCitations) {
+      $("html").toggleClass("hide-citations");
+    }
+    if (options.hidePageTabs) {
+      $("html").toggleClass("hide-page-tabs");
+    }
+    if (options.hideViewTabs) {
+      $("html").toggleClass("hide-view-tabs");
+    }
+    if (options.hideAuditData) {
+      $("html").toggleClass("hide-audit-data");
+    }
+    if (options.hideInlineImages) {
+      $("html").toggleClass("hide-inline-images");
+    }
+    if (options.hideComments) {
+      $("html").toggleClass("hide-comments");
+    }
+    if (options.hideHeadingExtras) {
+      $("html").toggleClass("hide-heading-extras");
+    }
+    if (options.hideEdits) {
+      $("html").toggleClass("hide-edits");
+    }
+    if (options.hideConnections) {
+      $("html").toggleClass("hide-connections");
+    }
+    if (options.hideCategories) {
+      $("html").toggleClass("hide-categories");
+    }
+  };
+  if (options.collapseSources) {
+    let toggleSourcesSection = function () {
+      $("html").toggleClass("expand-sources");
+    };
+    let toggleElement = $('<span class="toggle show-sources"><input type="checkbox" id="show_sources"><label for="show_sources"></label></span>');
+    toggleElement.find("input").change(function () {
+      toggleSourcesSection();
+    });
+    $("h2.x-sources").first().append(toggleElement);
+  }
+
+  // preserve the state from the previous page, we'll start in reading mode on this page (defaults to true if the feature has never been used before)
+  chrome.storage.sync.get("readingMode_toggle", function (result) {
+    let isToggledOn = (!result || false !== result.readingMode_toggle);
+    if (isToggledOn) {
+      toggleReadingMode();
+    }
+    // add the toggle to turn reading mode on/off while viewing the page instead of having to go into the extension for it
+    let toggleElement = $('<div class="toggle reading-mode .x-heading-widget"><input type="checkbox" id="reading_mode"' + (isToggledOn ? " checked" : "") + '><label for="reading_mode">Reading Mode</label>');
+    toggleElement.find("input").change(function () {
+      toggleReadingMode();
+      chrome.storage.sync.set({ "readingMode_toggle": this.checked });
+    });
+    $("#header").prepend(toggleElement);
+  });
+}
+
+checkIfFeatureEnabled("readingMode").then((result) => {
+  if (result && canTweakProfile()) {
+    import("../../core/toggleCheckbox.css");
+    import("./readingMode.css");
+    initReadingMode();
+  }
+});

--- a/src/features/readingMode/readingMode_options.js
+++ b/src/features/readingMode/readingMode_options.js
@@ -1,0 +1,91 @@
+import { registerFeature, OptionType } from "../../core/options/options_registry";
+
+const readingModeFeature = {
+  name: "Reading Mode",
+  id: "readingMode",
+  description: "Toggle the WikiTree interface on/off for readability while browsing profiles.",
+  category: "Style",
+  defaultValue: false,
+  options: [
+    {
+      id: "hideSideBar",
+      type: OptionType.CHECKBOX,
+      label: "Hide the right-hand column with DNA connections, images, etc.",
+      defaultValue: true,
+    },
+    {
+      id: "hideHeadingExtras",
+      type: OptionType.CHECKBOX,
+      label: "Hide extra widgets (copy) and icons (privacy) in the profile heading.",
+      defaultValue: true,
+    },
+    {
+      id: "hidePageTabs",
+      type: OptionType.CHECKBOX,
+      label: "Hide the tabs at the top of the profile.",
+      defaultValue: true,
+    },
+    {
+      id: "hideViewTabs",
+      type: OptionType.CHECKBOX,
+      label: "Hide the navigation buttons under the tabs section.",
+      defaultValue: true,
+    },
+    {
+      id: "hideAuditData",
+      type: OptionType.CHECKBOX,
+      label: "Hide the profile manager, last modified/accessed, etc.",
+      defaultValue: true,
+    },
+    {
+      id: "hideEdits",
+      type: OptionType.CHECKBOX,
+      label: "Hide edit links on the vitals and in the bio.",
+      defaultValue: true,
+    },
+    {
+      id: "hideInlineTables",
+      type: OptionType.CHECKBOX,
+      label: "Hide all tables in the bio.",
+      defaultValue: false,
+    },
+    {
+      id: "hideInlineImages",
+      type: OptionType.CHECKBOX,
+      label: "Hide inline images and captions in the bio.",
+      defaultValue: false,
+    },
+    {
+      id: "hideCitations",
+      type: OptionType.CHECKBOX,
+      label: "Hide citation superscripts within the biography.",
+      defaultValue: false,
+    },
+    {
+      id: "collapseSources",
+      type: OptionType.CHECKBOX,
+      label: "Collapse the entire Sources section (the header can still be expanded).",
+      defaultValue: true,
+    },
+    {
+      id: "hideComments",
+      type: OptionType.CHECKBOX,
+      label: "Hide comments, memories, and merges.",
+      defaultValue: true,
+    },
+    {
+      id: "hideConnections",
+      type: OptionType.CHECKBOX,
+      label: "Hide connections to famous people at the bottom.",
+      defaultValue: true,
+    },
+    {
+      id: "hideCategories",
+      type: OptionType.CHECKBOX,
+      label: "Hide categories.",
+      defaultValue: true,
+    },
+  ],
+};
+
+registerFeature(readingModeFeature);

--- a/src/features/register_feature_options.js
+++ b/src/features/register_feature_options.js
@@ -7,6 +7,7 @@ import { registerFeature } from "../core/options/options_registry";
 // the feature and options
 ////////////////////////////////////////////////////////////////////////////////
 
+import "./accessibility/accessibility_options.js";
 import "./agc/agc_options.js";
 import "./categoryDisplay/categoryDisplay_options.js";
 import "./change_family_lists/change_family_lists_options.js";
@@ -17,6 +18,7 @@ import "./format_source_reference_numbers/format_source_reference_numbers_option
 import "./g2g/g2g_options.js";
 import "./genderPredictor/gender_predictor_options.js";
 import "./randomProfile/randomProfile_options.js";
+import "./readingMode/readingMode_options.js";
 import "./redir_ext_links/redir_ext_links_options.js";
 import "./what_links_here/what_links_here_options.js";
 import "./wtPlus/wtPlus_options.js";
@@ -262,3 +264,16 @@ registerFeature({
   category: "Editing",
   defaultValue: true,
 });
+
+/*
+ * debugging features for development only
+ *
+registerFeature({
+  name: "Debug Profile Classes",
+  id: "debugProfileClasses",
+  description:
+    "Highlights various sections of page profiles (for testing the core profileClasses code).",
+  category: "Debug",
+  defaultValue: false,
+});
+// end debugging section */


### PR DESCRIPTION
This started out as an enhancement to alter the spacing of sources for people with vision problems, based on comments from a [G2G post](https://www.wikitree.com/g2g/1543388/preferred-formatting-of-references-and-sources).

As I got into identifying where all of the sources could be and how the lists were formatted, I realized that there was not really a good way to identify sections of a profile/biography simply based on IDs or classes in the HTML. I noticed [issue #125](https://github.com/wikitree/wikitree-browser-extension/issues/125) about creating a "reading mode" and started down that path, following the recommended design and adding some extra features of my own.

Because both of these features use the same logic, there are two files that I put in "core" so that can be shared:
- **profileClasses.js** is used by both the accessibility and reading mode features to decorate the profile with classes for styling
- **toggleCheckbox.css** is a simple CSS that turns a checkbox into a toggle switch styled for WikiTree (used by reading mode to toggle on/off at the top and also to toggle the sources section on and off when hidden by default)

This pull request adds the two new features under "Styles" where Dark Mode is located (plus an extra feature only for debugging):
* Accessibility Options
  - available options to toggle in the extension
    - Set the amount of spacing between list items
    - Remove extra spacing (merge adjacent &lt;ul&gt; items created when a blank line is entered between list items)
    - Limit the spacing to only the sources section (if turned off it will add spacing to all lists in the bio except for the TOC)
    - Bold the first segment of each source citation for readability (this is intended to eliminate the need for adding labels in front of sources like **Death:** but could be fragile if editors are using non-standard formatting)
    - Remove extra line breaks (removes &lt;br&gt; tags from within source &lt;li&gt; items)
    - Remove extra source labels (removes text like **Death:** from the beginning of sources)
  - good profiles to test this on are [[Smith-215783](https://www.wikitree.com/wiki/Smith-215783)] and [[Carter-39969](https://www.wikitree.com/wiki/Carter-39969)]
    - compare Smith-215783 [without](https://user-images.githubusercontent.com/18707259/224109513-21bf18fa-b082-4ec2-a4ee-a2c21f5ccb9e.png) and [with](https://user-images.githubusercontent.com/18707259/224109525-5613e072-a524-41da-86a7-93ac91c09cf2.png) accessibility mode
    - compare Carter-39969 [without](https://user-images.githubusercontent.com/18707259/224109408-fa0702db-1cc6-41a1-a1fd-004140621d40.png) and [with](https://user-images.githubusercontent.com/18707259/224109464-1f9cdb4a-9bf5-48e6-8fdd-45d2a6d585da.png) accessibility mode
    - compare how different the two look without accessibility mode
    - compare how similar the two look with accessibility mode
* Reading Mode [[screenshot](https://user-images.githubusercontent.com/18707259/224109541-7610c6af-fef0-4e6a-beb6-a83ba90be36b.png)]
  - available options to toggle in the extension
    - Hide the right-hand column with DNA connections, images, etc.
    - Hide extra widgets (copy) and icons (privacy) in the profile heading.
    - Hide the tabs at the top of the profile.
    - Hide the navigation buttons under the tabs section.
    - Hide the profile manager, last modified/accessed, etc.
    - Hide edit links on the vitals and in the bio.
    - Hide all inline tables in the bio (not including the TOC).
    - Hide inline images and captions in the bio.
    - Hide citation superscripts within the biography.
    - Collapse the entire Sources section (the header can still be expanded with a toggle switch).
    - Hide comments, memories, and merges.
    - Hide connections to famous people at the bottom.
    - Hide categories.
  - currently applies only to person profiles, spaces, and categories (slightly)
  - once it is enabled in the extension, reading mode can easily be toggled on/off with a switch under the menu area (and the state is persisted across pages as suggested in the original issue)
  - good profiles to test this in addition to those above are [[Example-30](https://www.wikitree.com/wiki/Example-30)], [[Category:Odd Fellows Cemetery, Carthage, Texas](https://www.wikitree.com/wiki/Category:Odd_Fellows_Cemetery,_Carthage,_Texas)], and [[Space:Carthage City and Odd Fellows Cemeteries, Carthage, Texas](https://www.wikitree.com/wiki/Space:Carthage_City_and_Odd_Fellows_Cemeteries%2C_Carthage%2C_Texas)]
* Debug Profile Classes [[screenshot](https://user-images.githubusercontent.com/18707259/224109588-bf1ca6e0-b744-4c9a-b391-8b4ea29a65a1.png)]
  - this simply includes an extra CSS file that applies to all of the classes identified by profileClasses.js to highlight individual sections and elements in the profile
  - this is not a feature that anyone not doing development would want to use, but others that might want to utilize profileClasses.js for their own features might want to enable it for their own testing
  - it is excluded from compilation in releases by comments in **content.js** and **register_feature_options.js** but can be included with a simple / added after the lone * to close the comment on the line before the `import`
