### PR TITLE
Readability bug fixes

### DIFF
--- a/src/features/readability/readability.js
+++ b/src/features/readability/readability.js
@@ -181,6 +181,13 @@ async function initReadability() {
       $("html").addClass("a11y-ref-clean");
     }
     if (options.citationFormat / 1 > 0 || options.citationSpacing / 1 !== 0 || options.cleanCitations || options.sortCitations) {
+      // remove whitespace from between adjacent citations to prevent 1234 instead of 1,2,3,4
+      $(".x-content sup.reference + sup.reference").each(function () {
+        let prev = this.previousSibling;
+        if (prev && prev.nodeType === 3 && (!prev.nodeValue || prev.nodeValue.replace(/\s+$/, "").length === 0)) {
+          prev.remove();
+        }
+      });
       $(".x-content sup.reference").filter(function () {
         return !(this.previousSibling && this.previousSibling.nodeType === 1 && $(this.previousSibling).is("sup.reference"));
       }).each(function () {

--- a/src/features/readability/readability_options.js
+++ b/src/features/readability/readability_options.js
@@ -79,7 +79,7 @@ import { isCategoryPage, isProfilePage, isSpacePage } from "../../core/pageType"
             options.hideConnections = options.hideConnections ? "1" : "0";
             options.hideCategories = options.hideCategories ? "1" : "0";
             options.hideBackground = options.hideBackground ? "1" : "0";
-            await Promise.all([store.set(settings)]);
+            await store.set(settings);
           }
         });
       }
@@ -247,7 +247,7 @@ const readabilityFeature = {
         {
           id: "removeSourceLabels",
           type: OptionType.SELECT,
-          label: "Remove bold labels from the beginning of sources",
+          label: "Remove bold labels (and leading asterisks) from the beginning of sources",
           values: [
             {
               value: 0,


### PR DESCRIPTION
Fixed issues found on Crabtree-3037:
- adjacent citations separated by only whitespace were not combined, so comma separators were missing
- leading asterisks in <ref> tags interfered with options to remove labels or to add bold at the beginning of sources

thanks Ian!