### PR TITLE
tweaks to Readability Options based on a few problematic profiles

### DIFF
--- a/src/core/profileClasses.js
+++ b/src/core/profileClasses.js
@@ -105,8 +105,26 @@ export function ensureProfileClasses() {
     // mark inline citations (both <ref> tags and "citation needed")
     $(".x-content sup.reference, .x-content sup > i > a[href$='/Help:Sources']").closest("sup").addClass("x-citation");
 
-    // mark inline images
-    $(".x-content table").has("a.image > img").addClass("x-inline-img");
+    // mark inline images (and the containing link)
+    $(".x-content a.image > img").addClass("x-inline-img").parent().addClass("x-inline-img");
+
+    // mark tables (and the row and cell) that only wrap a single inline image
+    $("tr:first-child > td > .x-inline-img")
+      .filter(function () {
+        var el = $(this);
+        if (el.siblings().length > 0) return false; // this should be the only element in the cell
+        el = el.parent();
+        if (el.siblings().length > 0) return false; // this should be the only cell in the row
+        el = el.parent();
+        if (el.siblings().length > 1) return false; // allow one additional row for the caption
+        return true;
+      })
+      .parent()
+      .addClass("x-inline-img")
+      .parent()
+      .addClass("x-inline-img")
+      .closest("table")
+      .addClass("x-inline-img");
 
     // mark inline tables (inline images must be marked first so that they will be excluded, along with the table of contents)
     $(".x-content table:not(.toc):not(.x-inline-img)").addClass("x-inline-table");
@@ -128,7 +146,13 @@ export function ensureProfileClasses() {
       .first()
       .addClass("x-sources")
       .nextUntil(".x-root-section, div.EDIT, .x-memories, br[clear] + div.SMALL")
-      .addClass("x-sources");
+      .addClass("x-sources")
+      .each(function () {
+        // sometimes text can be put in the sources section, such as "See also:" (only happens with leading whitespace)
+        if (this.previousSibling.nodeType == 3 && /\S/.test(this.previousSibling.nodeValue)) {
+          $(this.previousSibling).wrap('<span class="x-sources"></span>');
+        }
+      });
     $(".x-content ol.references").addClass("x-sources");
     // mark source list items separately
     $("ul.x-sources > li, ol.x-sources > li").addClass("x-src");

--- a/src/features/debugProfileClasses/debugProfileClasses.css
+++ b/src/features/debugProfileClasses/debugProfileClasses.css
@@ -14,7 +14,7 @@
 
 /* toc */
 .x-content .toc {
-  background: rgba(240,255,240,0.5) !important;
+  background: rgba(240, 255, 240, 0.5) !important;
 }
 
 /* status box */
@@ -98,7 +98,11 @@
   background: #ff0 !important;
 }
 
-.x-inline-img {
+table.x-inline-img {
+  border: 2px dashed #c60 !important;
+}
+
+img.x-inline-img {
   background: #444 !important;
   opacity: 0.5;
 }
@@ -108,11 +112,17 @@
 }
 
 .x-inline-table {
+  border: 2px dashed #066 !important;
   background: #999 !important;
   opacity: 0.5;
 }
 
-.x-section + h1, .x-section + h2, .x-section + h3, .x-section + h4, .x-section + h5, .x-section + h6 {
+.x-section + h1,
+.x-section + h2,
+.x-section + h3,
+.x-section + h4,
+.x-section + h5,
+.x-section + h6 {
   border-top: 1px dotted #876;
 }
 

--- a/src/features/readability/readability.css
+++ b/src/features/readability/readability.css
@@ -20,6 +20,10 @@
   font-weight: bold;
 }
 
+:root:not(.hide-src-label) .a11y-src-label + .a11y-src-first {
+  font-weight: unset;
+}
+
 .hide-src-br .a11y-src-br {
   display: none;
 }

--- a/src/features/readability/readability_options.js
+++ b/src/features/readability/readability_options.js
@@ -91,7 +91,7 @@ const readabilityFeature = {
   name: "Readability Options",
   id: "readability",
   description:
-    "Enable reading mode to toggle the WikiTree interface on and off when browsing profiles. Configure additional styling options to make profiles more readable. (<a href='https://www.wikitree.com/wiki/Space:WikiTree_Browser_Extension#Readability_Options' target='_blank'>More details</a>)",
+    "Enable reading mode to toggle the WikiTree interface on and off when browsing profiles. Configure additional styling options to make profiles more readable. (<a href='https://www.wikitree.com/wiki/Space:WikiTree_Readability_Options#Options' target='_blank'>More details</a>)",
   category: "Style",
   creators: [{ name: "Jonathan Duke", wikitreeid: "Duke-5773" }],
   contributors: [{ name: "Ian Beacall", wikitreeid: "Beacall-6" }],
@@ -222,12 +222,12 @@ const readabilityFeature = {
               text: "always",
             },
           ],
-          defaultValue: 255,
+          defaultValue: 0,
         },
         {
-          id: "removeSourceBreaks",
+          id: "removeSourceLabels",
           type: OptionType.SELECT,
-          label: "Remove explicit line breaks (<br> tags) from sources",
+          label: "Remove bold labels (and leading asterisks) from the beginning of sources",
           values: [
             {
               value: 0,
@@ -245,9 +245,9 @@ const readabilityFeature = {
           defaultValue: 0,
         },
         {
-          id: "removeSourceLabels",
+          id: "removeSourceBreaks",
           type: OptionType.SELECT,
-          label: "Remove bold labels (and leading asterisks) from the beginning of sources",
+          label: "Remove explicit line breaks (<br> tags) from sources",
           values: [
             {
               value: 0,
@@ -422,7 +422,7 @@ const readabilityFeature = {
               text: "always",
             },
           ],
-          defaultValue: 0,
+          defaultValue: 1,
         },
         {
           id: "hideHeadingExtras",
@@ -582,7 +582,7 @@ const readabilityFeature = {
               text: "always",
             },
           ],
-          defaultValue: 0,
+          defaultValue: 1,
         },
         {
           id: "hideInlineTables",


### PR DESCRIPTION
- updated profileClasses to distinguish between standalone images and tables with images inside
- fixed issue with Reagan-1 and whitespace before "See Also:" preventing it from being detected as part of the sources section
- enable any link referring to an ID or anchor in the sources section automatically expand them (not only for citations)
- minor handling of whitespace and asterisks before bold source labels (Crabtree-3037)
- updated link and a few defaults on the feature options