### PR TITLE
enhanced options for thumbnail image and DNA connections

### DIFF
--- a/src/core/profileClasses.js
+++ b/src/core/profileClasses.js
@@ -40,7 +40,9 @@ export function ensureProfileClasses() {
 
     // mark the thumbnail image container based on the heading
     $(".x-heading > .alpha").first().addClass("x-thumbnail");
-    $(".x-thumbnail img[alt*='upload photo'], .x-thumbnail img[alt*='upload image'], .x-thumbnail img[alt*='no photo'], .x-thumbnail img[alt*='no image']")
+    $(
+      ".x-thumbnail img[alt*='upload photo'], .x-thumbnail img[alt*='upload image'], .x-thumbnail img[alt*='no photo'], .x-thumbnail img[alt*='no image']"
+    )
       .closest(".x-thumbnail")
       .addClass("x-thumbnail-default");
 
@@ -110,6 +112,9 @@ export function ensureProfileClasses() {
         }).length > 0
       ) {
         el.addClass("x-sidebar-dna");
+        if (!el.find("ul").length > 0) {
+          el.addClass("x-dna-no-carriers");
+        }
       } else if (el.find("a[href^='/g2g/']").length > 0) {
         // G2G posts
         el.addClass("x-sidebar-posts");

--- a/src/features/debugProfileClasses/debugProfileClasses.css
+++ b/src/features/debugProfileClasses/debugProfileClasses.css
@@ -53,6 +53,12 @@
   border-color: #ff0 !important;
 }
 
+.x-sidebar-dna.x-dna-no-carriers strong,
+.x-sidebar-dna.x-dna-no-carriers a,
+.x-sidebar-dna.x-dna-no-carriers {
+  color: #ffc !important;
+}
+
 .x-sidebar-images {
   border-color: #090 !important;
 }

--- a/src/features/readability/readability.css
+++ b/src/features/readability/readability.css
@@ -85,7 +85,8 @@ sup.reference {
   display: none !important;
 }
 
-.hide-sidebar-dna .x-sidebar-dna {
+.hide-sidebar-dna .x-sidebar-dna,
+.hide-dna-no-carriers .x-dna-no-carriers {
   display: none !important;
 }
 
@@ -147,10 +148,7 @@ sup.reference {
   display: none !important;
 }
 
-.hide-default-thumbnail .x-thumbnail-default {
-  display: none !important;
-}
-
+.hide-default-thumbnail .x-thumbnail-default,
 .hide-thumbnail .x-thumbnail {
   display: none !important;
 }

--- a/src/features/readability/readability.js
+++ b/src/features/readability/readability.js
@@ -334,12 +334,14 @@ async function initReadability() {
   // toggle hidden elements (either always or in reading mode only)
   let initToggleOptions = true;
   toggleReadingMode = function () {
-    let isToggled = function (option) {
+    let isToggled = function (option, flags) {
+      let alwaysFlag = ((flags || 0) ^ 0x7e) | 0x81; // negate the flag bits and set the always and reading bits
+      let readingFlag = (flags || 0) | 1; // set the reading bit
       if (option) {
         if (initToggleOptions) {
-          return option % 4 > 2 || (options.readingMode_toggle && option % 2 > 0);
+          return option % 256 === alwaysFlag || (options.readingMode_toggle && option % 128 === readingFlag);
         } else {
-          return option % 4 === 1;
+          return option % 256 === readingFlag;
         }
       }
       return 0;
@@ -366,7 +368,9 @@ async function initReadability() {
     if (isToggled(options.hideForumPosts)) {
       $("html").toggleClass("hide-sidebar-posts");
     }
-    if (isToggled(options.hideDNAConnections)) {
+    if (isToggled(options.hideDNAConnections, 2)) {
+      $("html").toggleClass("hide-dna-no-carriers");
+    } else if (isToggled(options.hideDNAConnections)) {
       $("html").toggleClass("hide-sidebar-dna");
     }
     if (isToggled(options.hideSidebarImages)) {
@@ -414,14 +418,10 @@ async function initReadability() {
     if (isToggled(options.hideHeadingExtras)) {
       $("html").toggleClass("hide-heading-extras");
     }
-    if (options.hideThumbnail / 1 > 0) {
-      if (options.hideThumbnail % 256 === 253) {
-        if (initToggleOptions) {
-          $("html").toggleClass("hide-default-thumbnail");
-        }
-      } else if (isToggled(options.hideThumbnail)) {
-        $("html").toggleClass("hide-thumbnail");
-      }
+    if (isToggled(options.hideThumbnail, 2)) {
+      $("html").toggleClass("hide-default-thumbnail");
+    } else if (isToggled(options.hideThumbnail)) {
+      $("html").toggleClass("hide-thumbnail");
     }
     if (isToggled(options.hideEdits)) {
       $("html").toggleClass("hide-edits");

--- a/src/features/readability/readability_options.js
+++ b/src/features/readability/readability_options.js
@@ -482,6 +482,14 @@ const readabilityFeature = {
                   text: "in reading mode",
                 },
                 {
+                  value: 3,
+                  text: "in reading mode when empty",
+                },
+                {
+                  value: 253,
+                  text: "always when empty",
+                },
+                {
                   value: 255,
                   text: "always",
                 },
@@ -588,8 +596,12 @@ const readabilityFeature = {
                   text: "in reading mode",
                 },
                 {
+                  value: 3,
+                  text: "in reading mode when default",
+                },
+                {
                   value: 253,
-                  text: "only if default",
+                  text: "always when default",
                 },
                 {
                   value: 255,


### PR DESCRIPTION
The thumbnail image and DNA connections have special options for when to hide them. Since they are always shown on the page whether a user has uploaded an image or connected any DNA kits, special options were added to handle those cases only.
- never
- in reading mode
- **in reading mode when empty** (or default)
- **always when empty** (or default)
- always
