### PR TITLE
bug fix for citations in Readability Options

### DIFF
--- a/src/core/profileClasses.js
+++ b/src/core/profileClasses.js
@@ -72,7 +72,7 @@ export function ensureProfileClasses() {
 
     // mark alert boxes (like research notes, orphaned profile, etc.)
     $(
-      "x-content > .status, .x-content > a[name]:last-of-type ~ .box.orange, .x-content:not(* > a[name]) > .box.orange"
+      ".x-content > .status, .x-content > .projectbox, .x-content > a[name]:last-of-type ~ .box.orange, .x-content:not(* > a[name]) > .box.orange"
     ).addClass("x-alert");
 
     // mark the sidebar to the right (with DNA connections, images, collaboration, etc.)
@@ -179,6 +179,12 @@ export function ensureProfileClasses() {
 
     // mark inline tables (inline images must be marked first so that they will be excluded, along with the table of contents)
     $(".x-content table:not(.toc):not(.x-inline-img)").addClass("x-inline-table");
+
+    // unmark inline images that are inside stickers, project boxes, or inline tables
+    $(".x-inline-table .x-inline-img, .x-sticker .x-inline-img, .x-alert .x-inline-img").removeClass("x-inline-img");
+
+    // unmark inline tables that are inside stickers, project boxes, etc.
+    $(".x-sticker .x-inline-table, .x-alert .x-inline-table").removeClass("x-inline-table");
 
     // mark root sections in content (h2 only)
     $(".x-content a[name] + h1, .x-content a[name] + h2").prev().addClass("x-root-section x-section");

--- a/src/features/readability/readability.js
+++ b/src/features/readability/readability.js
@@ -47,7 +47,7 @@ async function initReadability() {
       }
     });
   }
-  if (options.removeBackReferences && options.removeBackReferences % 4 > 0) {
+  if (options.removeBackReferences % 4 > 0) {
     // if enabled, remove back references first so we don't have to skip over them later
     $(".x-src").each(function () {
       let li = $(this);
@@ -69,13 +69,13 @@ async function initReadability() {
   }
   if (options.removeSourceBreaks / 1 || options.removeSourceLabels || options.boldSources) {
     let qy = $(".x-src");
-    if (options.removeSourceBreaks && options.removeSourceBreaks % 4 > 0) {
+    if (options.removeSourceBreaks % 4 > 0) {
       qy.each(function () {
         let li = $(this);
         li.find("br").addClass("a11y-src-br").after(" ");
       });
     }
-    if (options.removeSourceLabels && options.removeSourceLabels % 4 > 0) {
+    if (options.removeSourceLabels % 4 > 0) {
       qy.each(function () {
         let li = $(this);
         li.contents().each(function () {
@@ -134,7 +134,7 @@ async function initReadability() {
           .removeClass("a11y-src-label");
       });
     }
-    if (options.boldSources && options.boldSources % 4 > 0) {
+    if (options.boldSources % 4 > 0) {
       qy.each(function (index) {
         let li = $(this);
         let state = 1;
@@ -222,7 +222,7 @@ async function initReadability() {
       });
     }
   }
-  if (options.hideCitations && options.hideCitations % 4 !== 3) {
+  if (options.hideCitations % 256 !== 255) {
     // no reason to modify citations if they are always hidden
     if (options.citationSize / 1 !== 100) {
       document.documentElement.style.setProperty("--a11y-citation-size", options.citationSize / 1 + "%");
@@ -302,7 +302,7 @@ async function initReadability() {
           }
         });
     }
-    if (options.collapseSources && options.collapseSources / 1 > 0) {
+    if (options.collapseSources / 1 > 0) {
       // when clicking on a citation, make sure that the sources are not collapsed
       $(".x-content sup.reference a, .x-content a[href^='#']")
         .filter(function () {


### PR DESCRIPTION
It should only skip when the user has "always" hide selected. It was previously also skipping if the user had selected to "never" hide citations.