### PR TITLE
addition to Readability Options for indentation of "See also:"

### DIFF
--- a/src/core/profileClasses.js
+++ b/src/core/profileClasses.js
@@ -207,10 +207,18 @@ export function ensureProfileClasses() {
       .each(function () {
         // sometimes text can be put in the sources section, such as "See also:" (only happens with leading whitespace)
         if (this.previousSibling.nodeType == 3 && /\S/.test(this.previousSibling.nodeValue)) {
-          $(this.previousSibling).wrap('<span class="x-sources"></span>');
+          $(this.previousSibling).wrap('<p class="x-sources"></p>');
         }
       });
     $(".x-content ol.references").addClass("x-sources");
+
+    // mark plain-text elements at the root of the sources section
+    $(".x-content > p.x-sources")
+      .filter(function () {
+        return this.childNodes.length === 1 && this.childNodes[0].nodeType === 3;
+      })
+      .addClass("x-text-only");
+
     // mark source list items separately
     $("ul.x-sources > li, ol.x-sources > li").addClass("x-src");
 

--- a/src/core/profileClasses.js
+++ b/src/core/profileClasses.js
@@ -215,7 +215,13 @@ export function ensureProfileClasses() {
     // mark plain-text elements at the root of the sources section
     $(".x-content > p.x-sources")
       .filter(function () {
-        return this.childNodes.length === 1 && this.childNodes[0].nodeType === 3;
+        return (
+          $(this)
+            .children()
+            .filter(function () {
+              return !(this.nodeType === 3 || $(this).is("a[name]:empty, a[id]:empty, span[id]:empty"));
+            }).length === 0
+        );
       })
       .addClass("x-text-only");
 

--- a/src/features/readability/readability.js
+++ b/src/features/readability/readability.js
@@ -67,6 +67,9 @@ async function initReadability() {
       });
     });
   }
+  if (options.indentSrcPlainText) {
+    $(".x-sources.x-text-only").wrapInner('<dl class="x-sources x-text-only"><dd></dd></dl>').children().unwrap();
+  }
   if (options.removeSourceBreaks / 1 || options.removeSourceLabels || options.boldSources) {
     let qy = $(".x-src");
     if (options.removeSourceBreaks % 4 > 0) {

--- a/src/features/readability/readability_options.js
+++ b/src/features/readability/readability_options.js
@@ -187,7 +187,7 @@ const readabilityFeature = {
         {
           id: "collapseSources",
           type: OptionType.SELECT,
-          label: "Collapse the entire sources section",
+          label: "Collapse the entire Sources section",
           values: [
             {
               value: 0,
@@ -283,6 +283,12 @@ const readabilityFeature = {
             },
           ],
           defaultValue: 1,
+        },
+        {
+          id: "indentSrcPlainText",
+          type: OptionType.CHECKBOX,
+          label: 'Indent plain text (like "See also:") in the Sources section',
+          defaultValue: false,
         },
       ],
     },


### PR DESCRIPTION
This adds an option for indentation of "See also:" and any other plain-text elements within the sources section.

It has the same effect as prefixing it with a colon (":See also:") in the biography, but this way editors don't have to do custom formatting or indentation, which will hopefully promote more standard formatting across all profiles.