### PR TITLE
prevent Sticky Header overlapping the page

### DIFF
--- a/src/features/sticky_header/sticky_header.css
+++ b/src/features/sticky_header/sticky_header.css
@@ -65,6 +65,25 @@
   }
 }
 
+@media only screen and (max-width: 1299px) {
+  .sticky-header .wrapper #header .search form input[type="text"] {
+    width: 125px;
+  }
+
+  .sticky-header .wrapper #header .search form input[type="text"]:first-child {
+    width: 95px;
+  }
+
+  .sticky-header .wrapper #watchlistSuggestionKeys {
+    width: 250px !important;
+  }
+
+  .sticky-header .wrapper .pureCssMenui0 .person {
+    max-width: 100px;
+    max-height: 11px;
+  }
+}
+
 @media only screen and (max-width: 979px) {
   .sticky-header .wrapper {
     --header-height: 60px !important;
@@ -89,14 +108,6 @@
 
   .sticky-header .wrapper #header .logo img {
     display: none;
-  }
-
-  .sticky-header .wrapper #header .search form input[type="text"] {
-    width: 125px;
-  }
-
-  .sticky-header .wrapper #header .search form input[type="text"]:first-child {
-    width: 95px;
   }
 }
 


### PR DESCRIPTION
This shrinks the text fields a little bit and also limits the width of the "person" menu item which can vary based on the length of the last name so that the menu won't drop into the page area.

Example: https://www.wikitree.com/wiki/Van_Munster-106
Absurd example to show how it would get cut off: https://www.wikitree.com/genealogy/ABCDEFGHIJKLMNOPQRSTUVWXYZ
