### PR TITLE
Correct handling of profile with no dates. Do not check profile added by connecting profile Id. When the Change Summary Options feature is enabled, place the BioCheck results with those Save buttons.

### DIFF
--- a/src/features/bioCheck/PersonDate.js
+++ b/src/features/bioCheck/PersonDate.js
@@ -62,6 +62,8 @@ export class PersonDate {
     if (bDay != null && bDay.length > 0) {
       this.personDate.birthDateString = bDay;
       this.personDate.birthDate = this.getDate(this.personDate.birthDateString);
+    } else {
+      this.personDate.hasBirthDate = false;
     }
     if (this.personDate.lastDateCheckedEmpty) {
       this.personDate.hasBirthDate = false;
@@ -69,6 +71,8 @@ export class PersonDate {
     if (dDay != null && dDay.length > 0) {
       this.personDate.deathDateString = dDay;
       this.personDate.deathDate = this.getDate(this.personDate.deathDateString);
+    } else {
+      this.personDate.hasDeathDate = false;
     }
     if (this.personDate.lastDateCheckedEmpty) {
       this.personDate.hasDeathDate = false;


### PR DESCRIPTION
Do not check sources when a profile is added (connected) from an existing Id. When the Change Summary Options feature is enabled, place the BioCheck results with those Save buttons.