### PR TITLE
Updated styles on WBE options page

### DIFF
--- a/public/main.css
+++ b/public/main.css
@@ -7,6 +7,20 @@ h6 {
   color: #333333;
 }
 
+a {
+  color: #060;
+  text-decoration: underline;
+  outline: 0;
+}
+a:active {
+  color: #8ec641;
+  text-decoration: none;
+}
+a:hover {
+  text-decoration: none;
+  background: #ffe270;
+}
+
 html,
 body,
 h1 {
@@ -28,7 +42,7 @@ html {
   flex-direction: row;
   justify-content: space-between;
 }
-.feature-header-left{
+.feature-header-left {
   display: flex;
 }
 .feature-name {
@@ -39,11 +53,14 @@ html {
   padding-left: 10px;
 }
 .feature-author {
-  align-items: right;
+  text-align: right;
 }
 .feature-description {
   padding: 10px 0 0 70px;
   font-size: medium;
+}
+.feature-link {
+  font-size: 75%;
 }
 .feature-options {
   padding: 10px 0 0 70px;
@@ -52,11 +69,15 @@ html {
 .feature-options-button,
 #options #backup button {
   border-radius: 34px;
-  background-color: #8fc641;
+  background-color: #ddd;
   font-size: medium;
   width: 120px;
   border: 0px;
   margin-left: 20px;
+  cursor: pointer;
+}
+.feature-options-button:hover {
+  background-color: #8fc641;
 }
 
 /* Option elements */
@@ -92,19 +113,31 @@ html {
   display: inline-block;
 }
 
+/* Make the header (h1) sticky */
+body {
+  position: relative;
+  padding-top: 70px;
+}
+#options h1 {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  background-color: #f7f6f0;
+  -webkit-box-shadow: 0 0 10px 3px rgba(0, 0, 0, 0.13);
+  box-shadow: 0 0 6px 2px rgba(0, 0, 0, 0.13);
+  height: 40px;
+  z-index: 100;
+}
 #options h1,
 #options h2 {
-  background: url("https://www.wikitree.com/images/header-bg-sm.gif") bottom repeat-x #f7f6f0;
-  height: 47px;
   padding: 0.5em;
-  position: relative;
   font-size: 2em;
 }
 #options h2 {
-  height: auto;
+  position: relative;
   padding-bottom: 1em;
   background-color: #e1f0b4;
-  background-image: none;
 }
 #options #h1Text {
   margin-left: 1em;
@@ -196,12 +229,15 @@ h1 .feature-toggle {
 h1 #default {
   float: right;
   position: relative;
-  display: inline-block;
   width: 60px;
   height: 34px;
   border-radius: 34px;
   border: 0;
   font-weight: bold;
+  cursor: pointer;
+}
+h1 #default:hover {
+  background-color: #8fc641;
 }
 h1 #default:active {
   box-shadow: 0;

--- a/public/main.css
+++ b/public/main.css
@@ -129,6 +129,47 @@ body {
   height: 40px;
   z-index: 100;
 }
+h2[id^="category_"] {
+  scroll-margin-top: 90px;
+}
+:root {
+  scroll-behavior: smooth;
+}
+
+#categoryBar {
+  position: fixed;
+  top: 62px;
+  left: 0;
+  right: 0;
+  background-color: #fff;
+  -webkit-box-shadow: 0 0 10px 3px rgba(0, 0, 0, 0.13);
+  box-shadow: 0 0 6px 2px rgba(0, 0, 0, 0.13);
+  height: 28px;
+  z-index: 99;
+  overflow: hidden;
+}
+#categoryBar > ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  line-height: 32px;
+  text-align: center;
+}
+#categoryBar > ul > li {
+  display: inline-block;
+  margin: 0 1em;
+}
+#categoryBar > ul > li > a {
+  text-decoration: none;
+  padding: 2px 8px;
+}
+#categoryBar > ul > li:first-child {
+  margin-left: 0;
+}
+#categoryBar > ul > li:last-child {
+  margin-right: 0;
+}
+
 #options h1,
 #options h2 {
   padding: 0.5em;

--- a/public/main.css
+++ b/public/main.css
@@ -7,6 +7,12 @@ h6 {
   color: #333333;
 }
 
+body {
+  /* set to match injected stylesheet from Chrome */
+  font-family: "Segoe UI", Tahoma, sans-serif;
+  font-size: 75%;
+}
+
 a {
   color: #060;
   text-decoration: underline;

--- a/src/features/readability/readability_options.js
+++ b/src/features/readability/readability_options.js
@@ -91,7 +91,8 @@ const readabilityFeature = {
   name: "Readability Options",
   id: "readability",
   description:
-    "Enable reading mode to toggle the WikiTree interface on and off when browsing profiles. Configure additional styling options to make profiles more readable. (<a href='https://www.wikitree.com/wiki/Space:WikiTree_Readability_Options#Options' target='_blank'>More details</a>)",
+    "Enable reading mode to toggle the WikiTree interface on and off when browsing profiles. Configure additional styling options to make profiles more readable.",
+  link: "https://www.wikitree.com/wiki/Space:WikiTree_Readability_Options#Options",
   category: "Style",
   creators: [{ name: "Jonathan Duke", wikitreeid: "Duke-5773" }],
   contributors: [{ name: "Ian Beacall", wikitreeid: "Beacall-6" }],

--- a/src/features/register_feature_options.js
+++ b/src/features/register_feature_options.js
@@ -72,7 +72,8 @@ registerFeature({
   id: "accessKeys",
   description:
     "Adds access keys. g: G2G Recent Activity; r: Random Profile, n: Nav Home Page;" +
-    " h: Help Search; s: Save; e: Edit; k: Category; p: Preview. (<a href='https://www.wikitree.com/wiki/Space:WikiTree_Browser_Extension#Access_Keys' target='_blank'>More details</a>)",
+    " h: Help Search; s: Save; e: Edit; k: Category; p: Preview.",
+  link: "https://www.wikitree.com/wiki/Space:WikiTree_Browser_Extension#Access_Keys",
   category: "Global",
   creators: [{ name: "Ian Beacall", wikitreeid: "Beacall-6" }],
   contributors: [],

--- a/src/options.js
+++ b/src/options.js
@@ -14,6 +14,8 @@ features.forEach(function (feature) {
   }
 });
 
+$("h1").first().after('<div id="categoryBar"><ul></ul></div>');
+
 // NOTE: This is called recursively
 function fillOptionsDataFromUiElements(feature, options, optionsData) {
   const optionElementIdPrefix = feature.id + "_";
@@ -326,7 +328,10 @@ features.sort(function (a, b) {
 
 // adds HTML elements for each feature to the options page
 categories.forEach(function (category) {
-  $("#features").append(`<h2 data-category="${category}">${category} 
+  $("#categoryBar > ul")
+    .first()
+    .append(`<li><a href="#category_${category.replace(/\W+/g, "")}">${category}</a></li>`);
+  $("#features").append(`<h2 id="category_${category.replace(/\W+/g, "")}" data-category="${category}">${category} 
   <div class="feature-toggle">
   <label class="switch">
   <input type="checkbox">

--- a/src/options.js
+++ b/src/options.js
@@ -419,11 +419,11 @@ $(".feature-options-button").on("click", function () {
     let featureId = id.substring(0, index);
     let optionsElementId = `${featureId}_options`;
     if ($(`#${optionsElementId}`).is(":hidden")) {
-      $(`#${optionsElementId}`).slideDown();
-      $(this).text("Hide Options");
+      $(`#${optionsElementId}`).slideDown().get(0).scrollIntoView({ behavior: "smooth", block: "center" });
+      $(this).text("Hide options");
     } else {
       $(`#${optionsElementId}`).slideUp();
-      $(this).text("Show Options");
+      $(this).text("Show options");
     }
   }
 });
@@ -448,18 +448,35 @@ function addFeatureToOptionsPage(featureData) {
           </button>
         </div>
         <div class="feature-author">`;
-          if (featureData.creators && featureData.creators.length) {
-            featureHTML += `Created by: ` + featureData.creators.map((person) => `<a href="https://www.wikitree.com/wiki/${person.wikitreeid}" target="_blank">${person.name}</a>`).join(", ") + `.`;
-          }
-          if (featureData.contributors && featureData.contributors.length) {
-            featureHTML += `<br>Contributors: ` + featureData.contributors.map((person) => `<a href="https://www.wikitree.com/wiki/${person.wikitreeid}" target="_blank">${person.name}</a>`).join(", ") + `.`;
-          }
-          featureHTML += `
+  if (featureData.creators && featureData.creators.length) {
+    featureHTML +=
+      (featureData.creators.length > 1 ? `Creators: ` : `Creator: `) +
+      featureData.creators
+        .map(
+          (person) => `<a href="https://www.wikitree.com/wiki/${person.wikitreeid}" target="_blank">${person.name}</a>`
+        )
+        .join(", ");
+  }
+  if (featureData.contributors && featureData.contributors.length) {
+    featureHTML +=
+      `<br />` +
+      (featureData.contributors.length > 1 ? `Contributors: ` : `Contributor: `) +
+      featureData.contributors
+        .map(
+          (person) => `<a href="https://www.wikitree.com/wiki/${person.wikitreeid}" target="_blank">${person.name}</a>`
+        )
+        .join(", ");
+  }
+  featureHTML += `
         </div>
       </div>
       <div class="feature-content">
         <div class="feature-description">
-          ${featureData.description}
+          ${featureData.description}`;
+  if (featureData.link) {
+    featureHTML += ` <span class="feature-link">(<a href="${featureData.link}" target="_blank">More details</a>)</span>`;
+  }
+  featureHTML += `
         </div>
       </div>
     </div>


### PR DESCRIPTION
- set link colors to match WikiTree
- added "link" property to features to automatically show the "More details" link after the description consistently
- aligned creator/contributors (in both singular and plural forms, depending on the list) to the right and removed . at the end
- updated button colors to use hover feedback (gray to green)
- smooth scroll the feature options to the center when "Show options" is clicked
- made the header at the top sticky and added a category bar to quickly scroll to different sections