### PR TITLE
added and consolidated options for backup/restore of settings and data

### DIFF
--- a/public/main.css
+++ b/public/main.css
@@ -66,8 +66,7 @@ html {
   padding: 10px 0 0 70px;
   font-size: medium;
 }
-.feature-options-button,
-#options #backup button {
+.feature-options-button {
   border-radius: 34px;
   background-color: #ddd;
   font-size: medium;
@@ -246,45 +245,127 @@ input:checked + .slider:before {
   right: 1em;
 }
 
-#options #backup {
-  font-size: medium;
-  margin-bottom: 1em;
-}
-#options #backup h2 {
-  font-size: 1.5em;
-}
-#options #backup button {
-  display: inline-block;
-}
-#options #backupButtons {
-  display: block;
-  margin: 1em auto;
-}
-#options #backup button:active {
-  border: 2px solid gray;
-}
-
 h1 .feature-toggle {
   margin-left: 0.5em;
 }
-h1 #default {
+h1 #settings {
   float: right;
   position: relative;
-  width: 60px;
+}
+h1 #settings,
+#settingsDialog button {
+  background-color: #ddd;
+  padding: 0 17px;
   height: 34px;
+  line-height: 34px;
   border-radius: 34px;
   border: 0;
-  font-weight: bold;
+  font-size: 12pt;
+}
+h1 #settings:hover,
+#settingsDialog button:hover {
+  background-color: #8fc641;
   cursor: pointer;
 }
-h1 #default:hover {
-  background-color: #8fc641;
-}
-h1 #default:active {
+h1 #settings:active,
+#settingsDialog button:active {
   box-shadow: 0;
+}
+
+.modal {
+  position: fixed;
+  z-index: 999;
+  background: rgba(204, 204, 204, 0.6);
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+}
+.modal .dialog {
+  position: relative;
+  border: 1px solid #000;
+  background-color: #fff;
+  margin: calc(clamp(100px, calc(var(--dialog-height, 0px) + 51px), 580px) / -2) auto 0 auto;
+  top: 50%;
+  width: 80%;
+  height: clamp(100px, calc(var(--dialog-height, 0px) + 51px), 580px);
+  font-size: 12pt;
+}
+.modal .dialog:before {
+  content: " ";
+  display: block;
+  position: absolute;
+  background: none;
+  z-index: -1;
+  top: 0;
+  left: 0;
+  bottom: 0;
+  right: 0;
+  -webkit-box-shadow: 3px 3px 12px 6px rgba(0, 0, 0, 0.3);
+  box-shadow: 3px 3px 12px 6px rgba(0, 0, 0, 0.3);
+}
+.dialog .dialog-header {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 31px;
+  background-color: #ddd;
+  padding: 0 30px 0 10px;
+  line-height: 30px;
+  font-weight: bold;
+}
+.dialog .close {
+  position: absolute;
+  display: inline-block;
+  right: 0px;
+  top: 0px;
+  font-size: 11pt;
+  font-weight: normal;
+  padding: 0 10px;
+}
+.dialog .dialog-content {
+  position: absolute;
+  padding: 10px;
+  top: 31px;
+  left: 0;
+  bottom: 0;
+  right: 0;
+  overflow: auto;
+}
+.dialog .close,
+.dialog .close:visited,
+.dialog .close:active {
+  color: #000;
+  text-decoration: none;
+}
+.dialog .close:hover {
+  color: #fff;
+  background-color: #8fc641;
+  text-decoration: none;
+}
+
+#settingsDialog ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+#settingsDialog li {
+  margin-top: 10px;
+}
+#settingsDialog li:first-child {
+  margin-top: 0;
 }
 
 /* content */
 #wte-topMenuUL {
   margin-right: 1em;
+}
+
+.hide-unless-wikitree,
+.is-on-wikitree .hide-on-wikitree {
+  display: none;
+}
+.is-on-wikitree .hide-unless-wikitree {
+  display: revert;
 }

--- a/public/main.css
+++ b/public/main.css
@@ -7,6 +7,20 @@ h6 {
   color: #333333;
 }
 
+a {
+  color: #060;
+  text-decoration: underline;
+  outline: 0;
+}
+a:active {
+  color: #8ec641;
+  text-decoration: none;
+}
+a:hover {
+  text-decoration: none;
+  background: #ffe270;
+}
+
 html,
 body,
 h1 {
@@ -28,7 +42,7 @@ html {
   flex-direction: row;
   justify-content: space-between;
 }
-.feature-header-left{
+.feature-header-left {
   display: flex;
 }
 .feature-name {
@@ -39,11 +53,14 @@ html {
   padding-left: 10px;
 }
 .feature-author {
-  align-items: right;
+  text-align: right;
 }
 .feature-description {
   padding: 10px 0 0 70px;
   font-size: medium;
+}
+.feature-link {
+  font-size: 75%;
 }
 .feature-options {
   padding: 10px 0 0 70px;
@@ -52,11 +69,15 @@ html {
 .feature-options-button,
 #options #backup button {
   border-radius: 34px;
-  background-color: #8fc641;
+  background-color: #ddd;
   font-size: medium;
   width: 120px;
   border: 0px;
   margin-left: 20px;
+  cursor: pointer;
+}
+.feature-options-button:hover {
+  background-color: #8fc641;
 }
 
 /* Option elements */
@@ -92,19 +113,31 @@ html {
   display: inline-block;
 }
 
+/* Make the header (h1) sticky */
+body {
+  position: relative;
+  padding-top: 70px;
+}
+#options h1 {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  background-color: #f7f6f0;
+  -webkit-box-shadow: 0 0 10px 3px rgba(0, 0, 0, 0.13);
+  box-shadow: 0 0 6px 2px rgba(0, 0, 0, 0.13);
+  height: 40px;
+  z-index: 100;
+}
 #options h1,
 #options h2 {
-  background: url("https://www.wikitree.com/images/header-bg-sm.gif") bottom repeat-x #f7f6f0;
-  height: 47px;
   padding: 0.5em;
-  position: relative;
   font-size: 2em;
 }
 #options h2 {
-  height: auto;
+  position: relative;
   padding-bottom: 1em;
   background-color: #e1f0b4;
-  background-image: none;
 }
 #options #h1Text {
   margin-left: 1em;
@@ -196,12 +229,15 @@ h1 .feature-toggle {
 h1 #default {
   float: right;
   position: relative;
-  display: inline-block;
   width: 60px;
   height: 34px;
   border-radius: 34px;
   border: 0;
   font-weight: bold;
+  cursor: pointer;
+}
+h1 #default:hover {
+  background-color: #8fc641;
 }
 h1 #default:active {
   box-shadow: 0;

--- a/public/main.css
+++ b/public/main.css
@@ -129,6 +129,47 @@ body {
   height: 40px;
   z-index: 100;
 }
+h2[id^="category_"] {
+  scroll-margin-top: 90px;
+}
+:root {
+  scroll-behavior: smooth;
+}
+
+#categoryBar {
+  position: fixed;
+  top: 62px;
+  left: 0;
+  right: 0;
+  background-color: #fff;
+  -webkit-box-shadow: 0 0 10px 3px rgba(0, 0, 0, 0.13);
+  box-shadow: 0 0 6px 2px rgba(0, 0, 0, 0.13);
+  height: 28px;
+  z-index: 99;
+  overflow: hidden;
+}
+#categoryBar > ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  line-height: 32px;
+  text-align: center;
+}
+#categoryBar > ul > li {
+  display: inline-block;
+  margin: 0 1em;
+}
+#categoryBar > ul > li > a {
+  text-decoration: none;
+  padding: 2px 8px;
+}
+#categoryBar > ul > li:first-child {
+  margin-left: 0;
+}
+#categoryBar > ul > li:last-child {
+  margin-right: 0;
+}
+
 #options h1,
 #options h2 {
   padding: 0.5em;

--- a/public/popup.html
+++ b/public/popup.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+	<head>
+		<meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
+		<script src="js/vendor.js"></script>
+		<title>WikiTree Browser Extension</title>
+	</head>
+	<body>
+
+	</body>
+	<script src="js/popup.js"></script>
+</html>

--- a/src/features/readability/readability_options.js
+++ b/src/features/readability/readability_options.js
@@ -91,7 +91,8 @@ const readabilityFeature = {
   name: "Readability Options",
   id: "readability",
   description:
-    "Enable reading mode to toggle the WikiTree interface on and off when browsing profiles. Configure additional styling options to make profiles more readable. (<a href='https://www.wikitree.com/wiki/Space:WikiTree_Readability_Options#Options' target='_blank'>More details</a>)",
+    "Enable reading mode to toggle the WikiTree interface on and off when browsing profiles. Configure additional styling options to make profiles more readable.",
+  link: "https://www.wikitree.com/wiki/Space:WikiTree_Readability_Options#Options",
   category: "Style",
   creators: [{ name: "Jonathan Duke", wikitreeid: "Duke-5773" }],
   contributors: [{ name: "Ian Beacall", wikitreeid: "Beacall-6" }],

--- a/src/features/register_feature_options.js
+++ b/src/features/register_feature_options.js
@@ -72,7 +72,8 @@ registerFeature({
   id: "accessKeys",
   description:
     "Adds access keys. g: G2G Recent Activity; r: Random Profile, n: Nav Home Page;" +
-    " h: Help Search; s: Save; e: Edit; k: Category; p: Preview. (<a href='https://www.wikitree.com/wiki/Space:WikiTree_Browser_Extension#Access_Keys' target='_blank'>More details</a>)",
+    " h: Help Search; s: Save; e: Edit; k: Category; p: Preview.",
+  link: "https://www.wikitree.com/wiki/Space:WikiTree_Browser_Extension#Access_Keys",
   category: "Global",
   creators: [{ name: "Ian Beacall", wikitreeid: "Beacall-6" }],
   contributors: [],

--- a/src/options.js
+++ b/src/options.js
@@ -14,6 +14,8 @@ features.forEach(function (feature) {
   }
 });
 
+$("h1").first().after('<div id="categoryBar"><ul></ul></div>');
+
 // NOTE: This is called recursively
 function fillOptionsDataFromUiElements(feature, options, optionsData) {
   const optionElementIdPrefix = feature.id + "_";
@@ -326,7 +328,10 @@ features.sort(function (a, b) {
 
 // adds HTML elements for each feature to the options page
 categories.forEach(function (category) {
-  $("#features").append(`<h2 data-category="${category}">${category} 
+  $("#categoryBar > ul")
+    .first()
+    .append(`<li><a href="#category_${category.replace(/\W+/g, "")}">${category}</a></li>`);
+  $("#features").append(`<h2 id="category_${category.replace(/\W+/g, "")}" data-category="${category}">${category} 
   <div class="feature-toggle">
   <label class="switch">
   <input type="checkbox">

--- a/src/options.js
+++ b/src/options.js
@@ -419,11 +419,11 @@ $(".feature-options-button").on("click", function () {
     let featureId = id.substring(0, index);
     let optionsElementId = `${featureId}_options`;
     if ($(`#${optionsElementId}`).is(":hidden")) {
-      $(`#${optionsElementId}`).slideDown();
-      $(this).text("Hide Options");
+      $(`#${optionsElementId}`).slideDown().get(0).scrollIntoView({ behavior: "smooth", block: "center" });
+      $(this).text("Hide options");
     } else {
       $(`#${optionsElementId}`).slideUp();
-      $(this).text("Show Options");
+      $(this).text("Show options");
     }
   }
 });
@@ -448,18 +448,35 @@ function addFeatureToOptionsPage(featureData) {
           </button>
         </div>
         <div class="feature-author">`;
-          if (featureData.creators && featureData.creators.length) {
-            featureHTML += `Created by: ` + featureData.creators.map((person) => `<a href="https://www.wikitree.com/wiki/${person.wikitreeid}" target="_blank">${person.name}</a>`).join(", ") + `.`;
-          }
-          if (featureData.contributors && featureData.contributors.length) {
-            featureHTML += `<br>Contributors: ` + featureData.contributors.map((person) => `<a href="https://www.wikitree.com/wiki/${person.wikitreeid}" target="_blank">${person.name}</a>`).join(", ") + `.`;
-          }
-          featureHTML += `
+  if (featureData.creators && featureData.creators.length) {
+    featureHTML +=
+      (featureData.creators.length > 1 ? `Creators: ` : `Creator: `) +
+      featureData.creators
+        .map(
+          (person) => `<a href="https://www.wikitree.com/wiki/${person.wikitreeid}" target="_blank">${person.name}</a>`
+        )
+        .join(", ");
+  }
+  if (featureData.contributors && featureData.contributors.length) {
+    featureHTML +=
+      `<br />` +
+      (featureData.contributors.length > 1 ? `Contributors: ` : `Contributor: `) +
+      featureData.contributors
+        .map(
+          (person) => `<a href="https://www.wikitree.com/wiki/${person.wikitreeid}" target="_blank">${person.name}</a>`
+        )
+        .join(", ");
+  }
+  featureHTML += `
         </div>
       </div>
       <div class="feature-content">
         <div class="feature-description">
-          ${featureData.description}
+          ${featureData.description}`;
+  if (featureData.link) {
+    featureHTML += ` <span class="feature-link">(<a href="${featureData.link}" target="_blank">More details</a>)</span>`;
+  }
+  featureHTML += `
         </div>
       </div>
     </div>

--- a/src/popup.js
+++ b/src/popup.js
@@ -1,0 +1,49 @@
+import $ from "jquery";
+import { restoreOptions, restoreData } from "./upload";
+
+if (window.location.hash) {
+  if (window.location.hash.indexOf("#Upload") === 0) {
+    let launch = function () {};
+    let exit = function () {
+      window.close();
+    };
+
+    function done() {
+      $("#btnLaunch").hide();
+      $("#btnDone").show();
+      exit();
+    }
+
+    function failed() {
+      alert("The file was not valid.");
+      $("#btnLaunch").show();
+      $("#btnDone").hide();
+    }
+
+    if (window.location.hash === "#UploadOptions") {
+      $("<h1>Upload Options<h1>").prependTo(document.body);
+      launch = function () {
+        restoreOptions().then(done).catch(failed);
+      };
+    } else if (window.location.hash === "#UploadData") {
+      $("<h1>Upload Data<h1>").prependTo(document.body);
+      launch = function () {
+        restoreData().then(done).catch(failed);
+      };
+    }
+
+    $(
+      '<div style="margin-top: 35vh; text-align: center;"><button id="btnLaunch">Choose File</button><button id="btnDone">Continue</button></div>'
+    ).appendTo(document.body);
+    $("#btnLaunch").on("click", () => {
+      launch();
+    });
+    $("#btnDone")
+      .hide()
+      .on("click", () => {
+        exit();
+      });
+
+    launch();
+  }
+}

--- a/src/upload.js
+++ b/src/upload.js
@@ -66,10 +66,12 @@ export function restoreData(onProcessing) {
         try {
           let data = JSON.parse(this.result);
           if (onProcessing) onProcessing();
-          chrome.tabs.query({ active: true, currentWindow: true }, function (tabs) {
-            chrome.tabs.sendMessage(tabs[0].id, { greeting: "restoreBackup", data: data }, function (response) {
-              resolve(data);
-            });
+          chrome.tabs.query({ url: "*://*.wikitree.com/*" }, function (tabs) {
+            if (tabs.length > 0) {
+              chrome.tabs.sendMessage(tabs[0].id, { greeting: "restoreBackup", data: data }, function (response) {
+                resolve(data);
+              });
+            }
           });
         } catch (ex) {
           reject({ error: "invalid", exception: ex });

--- a/src/upload.js
+++ b/src/upload.js
@@ -1,0 +1,80 @@
+import $ from "jquery";
+
+export function openFileChooser(readerCallback, readAs = "text") {
+  if (window.FileReader) {
+    let chooser = document.createElement("input");
+    chooser.type = "file";
+    chooser.addEventListener("change", function (e) {
+      if (chooser.files && chooser.files.length > 0) {
+        let reader = new FileReader();
+        if (readerCallback) {
+          reader.addEventListener("loadend", readerCallback);
+        }
+        switch (readAs ? readAs.toLowerCase() : "text") {
+          case "arraybuffer":
+            reader.readAsArrayBuffer(this.files[0]);
+            break;
+          case "binarystring":
+            reader.readAsBinaryString(this.files[0]);
+            break;
+          case "dataurl":
+            reader.readAsDataURL(this.files[0]);
+            break;
+          case "text":
+          default:
+            reader.readAsText(this.files[0]);
+            break;
+        }
+      }
+    });
+    $(chooser).trigger("click");
+  }
+}
+
+export function restoreOptions(onProcessing) {
+  return new Promise((resolve, reject) => {
+    openFileChooser(async function (e) {
+      if (!this.result) {
+        reject({ error: "empty" });
+      } else {
+        let isValid = false;
+        try {
+          let json = JSON.parse(this.result);
+          if (
+            (isValid = json.extension && json.extension.indexOf("WikiTree Browser Extension") === 0 && json.features)
+          ) {
+            if (onProcessing) onProcessing();
+            chrome.storage.sync.set(json.features, () => {
+              resolve(json.features);
+            });
+          }
+        } catch {}
+        if (!isValid) {
+          reject({ error: "invalid", content: this.result });
+        }
+      }
+    });
+  });
+}
+
+export function restoreData(onProcessing) {
+  return new Promise((resolve, reject) => {
+    openFileChooser(function (e) {
+      if (!this.result) {
+        reject({ error: "empty" });
+      } else {
+        try {
+          let data = JSON.parse(this.result);
+          if (onProcessing) onProcessing();
+          chrome.tabs.query({ active: true, currentWindow: true }, function (tabs) {
+            chrome.tabs.sendMessage(tabs[0].id, { greeting: "restoreBackup", data: data }, function (response) {
+              resolve(data);
+            });
+          });
+        } catch (ex) {
+          reject({ error: "invalid", exception: ex });
+        }
+      }
+    });
+  });
+}

--- a/webpack/webpack.common.js
+++ b/webpack/webpack.common.js
@@ -7,6 +7,7 @@ const srcDir = path.join(__dirname, "..", "src");
 module.exports = (env) => ({
   entry: {
     options: path.join(srcDir, "options.js"),
+    popup: path.join(srcDir, "popup.js"),
     content: path.join(srcDir, "content.js"),
   },
   output: {


### PR DESCRIPTION
(Separate pull request from style changes since this is a major feature change. See #294 first.)

The "Default" button at the top becomes "Settings" and will open up a dialog box. It includes options to enable default features (like the original default button did) and adds options to export/import the entire JSON for the feature options. An additional option allows you to clear the settings and reset everything, including all of the feature options, to the default values as if you had installed the extension from scratch.

If opened from a tab on the WikiTree domain, the options from backup/restore of data from features like My Menu and Extra Watchlist will also show up at the bottom of the dialog box (instead of being placed at the bottom of the feature list).

May need to be tested on Safari.