### PR TITLE
Improvements to source/space previews

### DIFF
--- a/src/features/readability/readability.css
+++ b/src/features/readability/readability.css
@@ -51,7 +51,7 @@ sup.reference {
   margin-left: var(--a11y-citation-spacing);
 }
 
-.a11y-ref-clean sup.reference a {
+.a11y-ref-clean sup.reference > a {
   text-decoration: none;
 }
 

--- a/src/features/register_feature_options.js
+++ b/src/features/register_feature_options.js
@@ -423,7 +423,7 @@ registerFeature({
   creators: [{ name: "Steve Harris", wikitreeid: "Harris-5439" }],
   contributors: [],
   defaultValue: false,
-  pages: [isProfilePage],
+  pages: [isProfilePage, isSpacePage],
 });
 
 registerFeature({

--- a/src/features/register_feature_options.js
+++ b/src/features/register_feature_options.js
@@ -421,9 +421,9 @@ registerFeature({
   description: "Enable source previews on inline references.",
   category: "Global",
   creators: [{ name: "Steve Harris", wikitreeid: "Harris-5439" }],
-  contributors: [],
+  contributors: [{ name: "Jonathan Duke", wikitreeid: "Duke-5773" }],
   defaultValue: false,
-  pages: [isProfilePage, isSpacePage],
+  pages: [isProfilePage, isProfileEdit, isSpacePage, isSpaceEdit],
 });
 
 registerFeature({
@@ -432,7 +432,7 @@ registerFeature({
   description: "Enable previews of Space Pages on hover.",
   category: "Global",
   creators: [{ name: "Steve Harris", wikitreeid: "Harris-5439" }],
-  contributors: [],
+  contributors: [{ name: "Jonathan Duke", wikitreeid: "Duke-5773" }],
   defaultValue: false,
   pages: [true],
 });

--- a/src/features/sourcepreview/sourcepreview.js
+++ b/src/features/sourcepreview/sourcepreview.js
@@ -16,7 +16,7 @@ checkIfFeatureEnabled("sPreviews").then((result) => {
                     var sPreview = document.createElement('div');
                     sPreview.setAttribute('id', 'sourcePreview');
                     sPreview.setAttribute('class', 'box rounded');
-                    sPreview.setAttribute('style', 'z-index:999; width: 450px; position:absolute;');
+                    sPreview.setAttribute('style', 'z-index:999; width: 450px; position:absolute; white-space: normal; font-size: 14px; font-style: normal; font-weight: normal;');
                     document.getElementById(this.id).appendChild(sPreview);
                     document.getElementById('sourcePreview').innerHTML = document.getElementById(sourceID).innerHTML;
                 },

--- a/src/features/sourcepreview/sourcepreview.js
+++ b/src/features/sourcepreview/sourcepreview.js
@@ -1,50 +1,95 @@
 /*
 Created By: Steve Harris (Harris-5439)
+Contributors: Jonathan Duke (Duke-5773)
 */
 
 import $ from "jquery";
+import "../../thirdparty/jquery.hoverDelay";
 import { checkIfFeatureEnabled } from "../../core/options/options_storage";
+
+function onHoverIn($element) {
+  hideActivePreview();
+  let $popup = $(
+    '<div id="activeSourcePreview" class="box rounded x-source-preview"' +
+      ' style="display: none; position:absolute; z-index:999; width: 450px; white-space: normal; font-size: 14px; font-style: normal; font-weight: normal;"' +
+      "></div>"
+  );
+
+  const citation = $element.closest(".reference").get(0);
+  const targetId = citation.id.replace("ref", "note").replace(/(_[0-9]+$)/g, "");
+  $popup.get(0).innerHTML = document.getElementById(targetId).innerHTML;
+  // remove back-reference links (based on readability.js:54)
+  $popup.contents().each(function () {
+    let el = $(this);
+    if (el.is(".a11y-back-ref, sup, a[href^='#_ref']:first-of-type, span:empty, a[name]:empty")) {
+      $(this).remove();
+      return true; // remove back-reference links
+    }
+    if (this.nodeValue && /^[*\s\u2191]*$/.test(this.nodeValue)) {
+      $(this).remove();
+      return true; // remove whitespace and the up arrow
+    }
+    return false;
+  });
+  $popup.appendTo(citation).fadeIn("fast");
+}
+
+function hidePreview($element) {
+  $element
+    .attr("id", "")
+    .css("z-index", "998")
+    .fadeOut("fast", function () {
+      $(this).remove();
+    });
+}
+
+function onHoverOut($element) {
+  hidePreview($element.closest(".reference").find(".x-source-preview"));
+}
+
+function hideActivePreview() {
+  hidePreview($(".x-source-preview[id='activeSourcePreview']"));
+}
+
+function attachHover(target) {
+  $(target)
+    .find(".reference > a")
+    .filter(function () {
+      // make sure each element is only wired up once
+      if (!this.xHasSourceHover) {
+        this.xHasSourceHover = true;
+        return true;
+      }
+      return false;
+    })
+    .hoverDelay({
+      delayIn: 500,
+      delayOut: 0,
+      handlerIn: onHoverIn,
+      handlerOut: onHoverOut,
+    });
+}
+
+async function initFeature() {
+  $(() => {
+    const $root = $('*[id="content"]').last();
+    if ($root.length > 0) {
+      const target = $root.get(0);
+      new MutationObserver(function (mutations) {
+        for (const mutation of mutations) {
+          if (mutation.type === "childList") {
+            attachHover(target);
+            break;
+          }
+        }
+      }).observe(target, { childList: true, subtree: true });
+      attachHover(target);
+    }
+  });
+}
 
 checkIfFeatureEnabled("sPreviews").then((result) => {
   if (result) {
-    sourcePreview();
-
-    function sourcePreview() {
-      if ($(".reference").length && $(".references").length) {
-        $(".reference").hover(
-          function (e) {
-            // jquery.hover() handlerIn (show sourcePreview)
-            var sourceID = this.id.replace("ref", "note").replace(/(_[0-9]+$)/g, "");
-            var sPreview = document.createElement("div");
-            sPreview.setAttribute("id", "sourcePreview");
-            sPreview.setAttribute("class", "box rounded");
-            sPreview.setAttribute(
-              "style",
-              "z-index:999; width: 450px; position:absolute; white-space: normal; font-size: 14px; font-style: normal; font-weight: normal;"
-            );
-            document.getElementById(this.id).appendChild(sPreview);
-            document.getElementById("sourcePreview").innerHTML = document.getElementById(sourceID).innerHTML;
-          },
-          function () {
-            // jqeury.hover() handlerOut (remove sourcePreview)
-            $("#sourcePreview").remove();
-          }
-        );
-      } else {
-      }
-    }
-    const targetNode = document.getElementById("previewbox");
-    const config = { childList: true };
-    const callback = (mutationList, observer) => {
-      for (const mutation of mutationList) {
-        if (mutation.type === "childList") {
-          sourcePreview();
-        }
-      }
-    };
-    const observer = new MutationObserver(callback);
-    if ($("#previewbox").length > 0) {
-      observer.observe(targetNode, config);
-    }
+    initFeature();
   }
 });

--- a/src/features/sourcepreview/sourcepreview.js
+++ b/src/features/sourcepreview/sourcepreview.js
@@ -2,42 +2,49 @@
 Created By: Steve Harris (Harris-5439)
 */
 
-import $ from 'jquery';
-import { checkIfFeatureEnabled } from "../../core/options/options_storage"
+import $ from "jquery";
+import { checkIfFeatureEnabled } from "../../core/options/options_storage";
 
 checkIfFeatureEnabled("sPreviews").then((result) => {
   if (result) {
-        sourcePreview();
+    sourcePreview();
 
-        function sourcePreview() {
-            if ($('.reference').length && $('.references').length) {
-                $('.reference').hover(function (e) { // jquery.hover() handlerIn (show sourcePreview)
-                    var sourceID = this.id.replace('ref', 'note').replace(/(_[0-9]+$)/g, '');
-                    var sPreview = document.createElement('div');
-                    sPreview.setAttribute('id', 'sourcePreview');
-                    sPreview.setAttribute('class', 'box rounded');
-                    sPreview.setAttribute('style', 'z-index:999; width: 450px; position:absolute; white-space: normal; font-size: 14px; font-style: normal; font-weight: normal;');
-                    document.getElementById(this.id).appendChild(sPreview);
-                    document.getElementById('sourcePreview').innerHTML = document.getElementById(sourceID).innerHTML;
-                },
-                    function () { // jqeury.hover() handlerOut (remove sourcePreview)
-                        $('#sourcePreview').remove();
-                    }
-                )
-            } else {}
-        }
-        const targetNode = document.getElementById('previewbox');
-        const config = { childList: true };
-        const callback = (mutationList, observer) => {
-            for (const mutation of mutationList) {
-                if (mutation.type === 'childList') {
-                    sourcePreview();
-                }
-            }
-        };
-        const observer = new MutationObserver(callback);
-        if ($('#previewbox').length > 0) {
-            observer.observe(targetNode, config);
-        }
+    function sourcePreview() {
+      if ($(".reference").length && $(".references").length) {
+        $(".reference").hover(
+          function (e) {
+            // jquery.hover() handlerIn (show sourcePreview)
+            var sourceID = this.id.replace("ref", "note").replace(/(_[0-9]+$)/g, "");
+            var sPreview = document.createElement("div");
+            sPreview.setAttribute("id", "sourcePreview");
+            sPreview.setAttribute("class", "box rounded");
+            sPreview.setAttribute(
+              "style",
+              "z-index:999; width: 450px; position:absolute; white-space: normal; font-size: 14px; font-style: normal; font-weight: normal;"
+            );
+            document.getElementById(this.id).appendChild(sPreview);
+            document.getElementById("sourcePreview").innerHTML = document.getElementById(sourceID).innerHTML;
+          },
+          function () {
+            // jqeury.hover() handlerOut (remove sourcePreview)
+            $("#sourcePreview").remove();
+          }
+        );
+      } else {
+      }
     }
-})
+    const targetNode = document.getElementById("previewbox");
+    const config = { childList: true };
+    const callback = (mutationList, observer) => {
+      for (const mutation of mutationList) {
+        if (mutation.type === "childList") {
+          sourcePreview();
+        }
+      }
+    };
+    const observer = new MutationObserver(callback);
+    if ($("#previewbox").length > 0) {
+      observer.observe(targetNode, config);
+    }
+  }
+});

--- a/src/features/spacepreview/spacepreview.js
+++ b/src/features/spacepreview/spacepreview.js
@@ -7,70 +7,140 @@ import $ from "jquery";
 import "../../thirdparty/jquery.hoverDelay";
 import { checkIfFeatureEnabled } from "../../core/options/options_storage";
 
-checkIfFeatureEnabled("spacePreviews").then((result) => {
-  if (result) {
-    $('.columns a[href*="/wiki/Space:"]').hoverDelay({
-      delayIn: 1000,
-      delayOut: 0,
-      handlerIn: function ($element) {
-        $("#spacePreview").remove();
-        let $popup = $(
-          '<div id="spacePreview" class="box rounded"' +
-            ' style="display: none; z-index:9999; max-height:450px; overflow: scroll; position:absolute; padding: 10px; font-style: normal; font-weight: normal; text-decoration: none;"' +
-            ">Loading...</div>"
-        );
+function onHoverIn($element) {
+  hideActivePreview();
+  let $popup = $(
+    '<div id="activeSpacePreview" class="box rounded x-space-preview"' +
+      ' style="display: none; position:absolute; z-index:9999; max-height:450px; overflow: scroll; overflow-x: auto; padding: 10px; font-style: normal; font-weight: normal; text-decoration: none;"' +
+      "></div>"
+  );
 
-        const targetSpaceId = decodeURIComponent($element[0].href.match(/\/wiki\/(Space:.*?)(#.*|$)/i)[1]);
-        let hasRedirect = false;
-        function populateSpacePreview(spaceId) {
-          // this can be recursive since getProfile does not handle redirects on space pages
-          try {
-            $.ajax({
-              url: "https://api.wikitree.com/api.php",
-              type: "POST",
-              dataType: "json",
-              data: {
-                action: "getProfile",
-                key: spaceId,
-                fields: "Bio",
-                bioFormat: "both",
-                resolveRedirect: 0,
-              },
-              xhrFields: { withCredentials: true },
-            }).done(function (results) {
-              let bio = null;
-              if (results && results.length && results[0] && results[0].profile && (bio = results[0].profile.bioHTML)) {
-                let redirectMatch;
-                if ((redirectMatch = results[0].profile.bio.match(/^\s*#REDIRECT \[\[\s*(Space:.*)\s*\]\]\s*$/))) {
-                  hasRedirect = true;
-                  populateSpacePreview(redirectMatch[1]);
-                } else {
-                  $popup.get(0).innerHTML =
-                    (hasRedirect
-                      ? `<div style="color: #c00; font-size: small; font-weight: bold;">[[${targetSpaceId}]] redirected to [[${results[0].page_name}]]</div>`
-                      : "") + bio;
-                  $popup.fadeIn("fast");
-                }
-              }
-            });
-          } catch (err) {
-            console.warn(err);
-            $("#spacePreview").remove();
+  const targetId = decodeURIComponent($element[0].href.match(/\/wiki\/(Space:.*?)(#.*|$)/i)[1]);
+  let redirectCount = 0;
+  function populatePreview(spaceId) {
+    // this can be recursive since getProfile does not handle redirects on space pages
+    try {
+      $.ajax({
+        url: "https://api.wikitree.com/api.php",
+        type: "POST",
+        dataType: "json",
+        data: {
+          action: "getProfile",
+          key: spaceId.replace(/ /g, "_"),
+          fields: "Bio",
+          bioFormat: "both",
+          resolveRedirect: 0,
+        },
+        xhrFields: { withCredentials: true },
+      }).done(function (results) {
+        let bio = null;
+        if (results && results.length && results[0] && results[0].profile && (bio = results[0].profile.bioHTML)) {
+          let redirectMatch;
+          if ((redirectMatch = results[0].profile.bio.match(/^\s*#REDIRECT \[\[\s*(Space:.*)\s*\]\]\s*$/))) {
+            // make sure we don't get stuck in an endless recursive loop of redirects
+            if (++redirectCount < 5) {
+              populatePreview(redirectMatch[1]);
+            }
+          } else {
+            $popup.get(0).innerHTML =
+              '<a href="#" class="popup-close" style="position: absolute; right: 0; top: 0; display: inline-block; padding: 0 7px; color: black; font-size: 14px; text-decoration: none;">&#x2716;</a>' +
+              (redirectCount > 0
+                ? `<div style="color: #c00; font-size: small; font-weight: bold;">[[${targetId}]] redirected ` +
+                  (redirectCount > 1 ? `${redirectCount} times` : "") +
+                  ` to [[${results[0].page_name}]]</div>`
+                : "") +
+              bio;
+            $popup
+              .find("a.popup-close")
+              .on("auxclick", function (e) {
+                e.stopPropagation();
+                e.preventDefault();
+              })
+              .on("click", function (e) {
+                e.stopPropagation();
+                e.preventDefault();
+                onCloseClicked($(this));
+              });
+            $popup.fadeIn("fast");
           }
         }
+      });
+    } catch (err) {
+      console.warn(err);
+      hideActivePreview();
+    }
+  }
 
-        populateSpacePreview(targetSpaceId);
-        $element.after($popup);
-      },
+  populatePreview(targetId);
+  $element.after($popup);
+}
+
+function hidePreview($element) {
+  $element
+    .attr("id", "")
+    .css("z-index", "9998")
+    .fadeOut("fast", function () {
+      $(this).remove();
     });
+}
 
-    // intercept clicks outside of the preview to close it
-    $(document).on("click", function (event) {
-      if ($(event.target).closest("#spacePreview").length === 0) {
-        $("#spacePreview").fadeOut("fast", function () {
-          $(this).remove();
-        });
+function onCloseClicked($element) {
+  hidePreview($element.closest(".x-space-preview"));
+}
+
+function hideActivePreview() {
+  hidePreview($(".x-space-preview[id='activeSpacePreview']"));
+}
+
+function attachHover(target) {
+  $(target)
+    .find('.columns a[href*="/wiki/Space:"]')
+    .filter(function () {
+      // make sure each element is only wired up once
+      if (!this.xHasSpaceHover) {
+        // don't wire up space previews inside other space preview windows
+        if ($(this).closest(".x-space-preview").length > 0) {
+          return false;
+        }
+        this.xHasSpaceHover = true;
+        return true;
       }
+      return false;
+    })
+    .hoverDelay({
+      delayIn: 500,
+      delayOut: 0,
+      handlerIn: onHoverIn,
     });
+}
+
+async function initFeature() {
+  $(() => {
+    const $root = $('*[id="content"]').last();
+    if ($root.length > 0) {
+      const target = $root.get(0);
+      new MutationObserver(function (mutations) {
+        for (const mutation of mutations) {
+          if (mutation.type === "childList") {
+            attachHover(target);
+            break;
+          }
+        }
+      }).observe(target, { childList: true, subtree: true });
+      attachHover(target);
+    }
+  });
+
+  // intercept clicks outside of the preview to close it
+  $(document).on("click", function (event) {
+    if ($(event.target).closest("#spacePreview").length === 0) {
+      hideActivePreview();
+    }
+  });
+}
+
+checkIfFeatureEnabled("spacePreviews").then((result) => {
+  if (result) {
+    initFeature();
   }
 });

--- a/src/features/spacepreview/spacepreview.js
+++ b/src/features/spacepreview/spacepreview.js
@@ -2,9 +2,9 @@
 Created By: Steve Harris (Harris-5439)
 */
 
-import $ from 'jquery';
-import '../../thirdparty/jquery.hoverDelay'
-import { checkIfFeatureEnabled } from "../../core/options/options_storage"
+import $ from "jquery";
+import "../../thirdparty/jquery.hoverDelay";
+import { checkIfFeatureEnabled } from "../../core/options/options_storage";
 
 checkIfFeatureEnabled("spacePreviews").then((result) => {
   if (result) {

--- a/src/features/spacepreview/spacepreview.js
+++ b/src/features/spacepreview/spacepreview.js
@@ -1,5 +1,6 @@
 /*
 Created By: Steve Harris (Harris-5439)
+Contributors: Jonathan Duke (Duke-5773)
 */
 
 import $ from "jquery";
@@ -8,40 +9,68 @@ import { checkIfFeatureEnabled } from "../../core/options/options_storage";
 
 checkIfFeatureEnabled("spacePreviews").then((result) => {
   if (result) {
-    $('.ten.columns a[href*="/wiki/Space:"], .sixteen.columns a[href*="/wiki/Space:"]').hoverDelay({
+    $('.columns a[href*="/wiki/Space:"]').hoverDelay({
       delayIn: 1000,
       delayOut: 0,
       handlerIn: function ($element) {
         $("#spacePreview").remove();
-        $("#spaceHover").attr("id", "");
-        console.log($element[0].href);
-        $element.attr("id", "spaceHover");
-        var sPreview = document.createElement("div");
-        sPreview.setAttribute("id", "spacePreview");
-        sPreview.setAttribute("class", "box rounded");
-        sPreview.setAttribute(
-          "style",
-          `z-index:9999; max-height:450px; overflow: scroll; position:absolute; padding: 10px; font-style: normal; font-weight: normal; text-decoration: none;`
+        let $popup = $(
+          '<div id="spacePreview" class="box rounded"' +
+            ' style="display: none; z-index:9999; max-height:450px; overflow: scroll; position:absolute; padding: 10px; font-style: normal; font-weight: normal; text-decoration: none;"' +
+            ">Loading...</div>"
         );
-        document.getElementById("spaceHover").parentElement.appendChild(sPreview);
-        $.ajax({
-          url: $element[0].href,
-          context: document.body,
-        }).done(function (result) {
-          var pageContent = $(result).find(".ten.columns").html();
+
+        const targetSpaceId = decodeURIComponent($element[0].href.match(/\/wiki\/(Space:.*?)(#.*|$)/i)[1]);
+        let hasRedirect = false;
+        function populateSpacePreview(spaceId) {
+          // this can be recursive since getProfile does not handle redirects on space pages
           try {
-            document.getElementById(
-              "spacePreview"
-            ).innerHTML = `<span style="float:right; font-weight:700;">click outside to close</span>${pageContent}`;
-          } catch {}
-        });
+            $.ajax({
+              url: "https://api.wikitree.com/api.php",
+              type: "POST",
+              dataType: "json",
+              data: {
+                action: "getProfile",
+                key: spaceId,
+                fields: "Bio",
+                bioFormat: "both",
+                resolveRedirect: 0,
+              },
+              xhrFields: { withCredentials: true },
+            }).done(function (results) {
+              let bio = null;
+              if (results && results.length && results[0] && results[0].profile && (bio = results[0].profile.bioHTML)) {
+                let redirectMatch;
+                if ((redirectMatch = results[0].profile.bio.match(/^\s*#REDIRECT \[\[\s*(Space:.*)\s*\]\]\s*$/))) {
+                  hasRedirect = true;
+                  populateSpacePreview(redirectMatch[1]);
+                } else {
+                  $popup.get(0).innerHTML =
+                    (hasRedirect
+                      ? `<div style="color: #c00; font-size: small; font-weight: bold;">[[${targetSpaceId}]] redirected to [[${results[0].page_name}]]</div>`
+                      : "") + bio;
+                  $popup.fadeIn("fast");
+                }
+              }
+            });
+          } catch (err) {
+            console.warn(err);
+            $("#spacePreview").remove();
+          }
+        }
+
+        populateSpacePreview(targetSpaceId);
+        $element.after($popup);
       },
     });
+
+    // intercept clicks outside of the preview to close it
+    $(document).on("click", function (event) {
+      if ($(event.target).closest("#spacePreview").length === 0) {
+        $("#spacePreview").fadeOut("fast", function () {
+          $(this).remove();
+        });
+      }
+    });
   }
-  $(document).on("click", function (event) {
-    if ($(event.target).closest("#spacePreview").length === 0) {
-      $("#spacePreview").remove();
-      $("#spaceHover").attr("id", "");
-    }
-  });
 });

--- a/src/features/spacepreview/spacepreview.js
+++ b/src/features/spacepreview/spacepreview.js
@@ -21,7 +21,7 @@ checkIfFeatureEnabled("spacePreviews").then((result) => {
         sPreview.setAttribute("class", "box rounded");
         sPreview.setAttribute(
           "style",
-          `z-index:9999; max-height:450px; overflow: scroll; position:absolute; padding: 10px;`
+          `z-index:9999; max-height:450px; overflow: scroll; position:absolute; padding: 10px; font-style: normal; font-weight: normal; text-decoration: none;`
         );
         document.getElementById("spaceHover").parentElement.appendChild(sPreview);
         $.ajax({

--- a/src/features/sticky_header/sticky_header.css
+++ b/src/features/sticky_header/sticky_header.css
@@ -25,6 +25,7 @@
   .sticky-header .wrapper #header,
   .sticky-header .qa-body-wrapper .qa-header {
     position: fixed;
+    z-index: 2147000000;
     top: 0;
     height: var(--header-height);
     background: none;
@@ -33,7 +34,6 @@
   .sticky-header .qa-body-wrapper .qa-header {
     width: 940px;
     background-color: #fff;
-    z-index: 1;
   }
 
   .sticky-header .wrapper #header::before {


### PR DESCRIPTION
If you compare the source files from the two features, they should look very similar now.

Both features use MutationObserver to wire up new hover events when elements are added to the page after it has loaded (from other features like What Links Here and Readability Options).

Space previews should work on any page now, including in the "preview" section when editing profiles.