### PR TITLE
Fix backup on Safari

### DIFF
--- a/public/main.css
+++ b/public/main.css
@@ -9,6 +9,8 @@ body {
   /* override the injected stylesheet from Chrome which is percentage-based to match the root size */
   font-family: "Open Sans", Helvetica, Arial, sans-serif;
   font-size: 1rem;
+  /* override Safari's semi-transparent background */
+  background-color: #fff;
 }
 
 h1,

--- a/public/options.css
+++ b/public/options.css
@@ -172,21 +172,36 @@ h1 #settings {
   position: relative;
 }
 h1 #settings,
-#settingsDialog button {
+#settingsDialog button,
+#settingsDialog a.button {
+  display: inline-block;
   background-color: #ddd;
+  color: #000;
   padding: 0 17px;
   height: 34px;
   line-height: 34px;
   border-radius: 34px;
   border: 0;
   font-size: 16px;
+  text-decoration: none;
 }
 h1 #settings:hover,
-#settingsDialog button:hover {
+#settingsDialog button:hover,
+#settingsDialog a.button:hover {
   background-color: #8fc641;
+  color: #000;
   cursor: pointer;
 }
 h1 #settings:active,
-#settingsDialog button:active {
+#settingsDialog button:active,
+#settingsDialog a.button:active {
+  color: #000;
   box-shadow: 0;
+}
+#settingsDialog a.button.download,
+#settingsDialog a.button.download:active {
+  background-color: #ffe270;
+}
+#settingsDialog a.button.download:hover {
+  background-color: #8fc641;
 }

--- a/src/core/common.js
+++ b/src/core/common.js
@@ -399,10 +399,16 @@ chrome.runtime.onMessage.addListener(function (request, sender, sendResponse) {
         backupObject.clipboard = JSON.stringify(req.result);
         let link = document.createElement("a");
         link.download = strDate() + "_WBE_backup.txt";
-        let blob = new Blob([JSON.stringify(backupObject)], { type: "text/plain" });
-        link.href = URL.createObjectURL(blob);
-        link.click();
-        URL.revokeObjectURL(link.href);
+        let json = JSON.stringify(backupObject);
+        if (!window.safari) {
+          link.href = "data:text/plain;base64," + window.btoa(json);
+          link.click();
+        } else {
+          let blob = new Blob([json], { type: "text/plain" });
+          link.href = URL.createObjectURL(blob);
+          link.click();
+          URL.revokeObjectURL(link.href);
+        }
       };
     };
   }

--- a/src/core/common.js
+++ b/src/core/common.js
@@ -369,6 +369,13 @@ export async function updateDraftList() {
   return true;
 }
 
+export function isWikiTreeUrl(url) {
+  if (url) {
+    return /^http(s)?:\/+((www|staging)\.)?wikitree\.com\//i.test(url);
+  }
+  return false;
+}
+
 function backupData(sendResponse) {
   const data = {};
   data.changeSummaryOptions = localStorage.LSchangeSummaryOptions;
@@ -377,12 +384,17 @@ function backupData(sendResponse) {
   const clipboardDB = window.indexedDB.open("Clipboard", window.idbv2);
   clipboardDB.onsuccess = function (event) {
     let cdb = clipboardDB.result;
-    let transaction = cdb.transaction(["Clipboard"]);
-    let req = transaction.objectStore("Clipboard").getAll();
-    req.onsuccess = function (event) {
-      data.clipboard = JSON.stringify(req.result);
+    try {
+      let transaction = cdb.transaction(["Clipboard"]);
+      let req = transaction.objectStore("Clipboard").getAll();
+      req.onsuccess = function (event) {
+        data.clipboard = JSON.stringify(req.result);
+        sendResponse({ ack: "feature data attached", backup: data });
+      };
+    } catch (e) {
+      console.warn(e); // we weren't able to export any clipboard data, but we can still download the rest
       sendResponse({ ack: "feature data attached", backup: data });
-    };
+    }
   };
 }
 

--- a/src/features/readability/readability.js
+++ b/src/features/readability/readability.js
@@ -310,15 +310,18 @@ async function initReadability() {
       $(".x-content sup.reference a, .x-content a[href^='#']")
         .filter(function () {
           if (!$(this).parent().is("sup.reference")) {
-            let el = document.getElementById(this.getAttribute("href").substring(1));
-            if (!el) {
-              el = document.getElementsByName(this.getAttribute("href").substring(1));
-              if (el.length > 0) {
-                el = el[0];
+            let refId = this.getAttribute("href").substring(1);
+            if (refId) {
+              let el = document.getElementById(refId);
+              if (!el) {
+                el = document.getElementsByName(this.getAttribute("href").substring(1));
+                if (el.length > 0) {
+                  el = el[0];
+                }
               }
-            }
-            if (el && $(el).closest(".x-sources").length > 0) {
-              return true; // any links to elements under the sources section should also trigger this
+              if (el && $(el).closest(".x-sources").length > 0) {
+                return true; // any links to elements under the sources section should also trigger this
+              }
             }
             return false; // any other links should not expand the sources
           }

--- a/src/features/readability/readability_options.js
+++ b/src/features/readability/readability_options.js
@@ -85,7 +85,7 @@ import { isCategoryPage, isProfilePage, isSpacePage } from "../../core/pageType"
       }
     });
   }
-})((browser || chrome).storage.sync);
+})((typeof browser !== "undefined" ? browser : chrome).storage.sync);
 
 const readabilityFeature = {
   name: "Readability Options",

--- a/src/features/readability/readability_options.js
+++ b/src/features/readability/readability_options.js
@@ -85,7 +85,7 @@ import { isCategoryPage, isProfilePage, isSpacePage } from "../../core/pageType"
       }
     });
   }
-})(chrome.storage.sync);
+})((browser || chrome).storage.sync);
 
 const readabilityFeature = {
   name: "Readability Options",

--- a/src/options.js
+++ b/src/options.js
@@ -484,11 +484,15 @@ $("#settings").on("click", function () {
           .format(now)
           .replace(":", "")
           .replace(" ", "_") + "_WBE_options.txt"; // formatted to match WBE data export
-      let blob = new Blob([json], { type: "text/plain" });
-      link.href = URL.createObjectURL(blob);
-      link.click();
-      URL.revokeObjectURL(link.href);
-      hideModal();
+      if (!window.safari) {
+        link.href = "data:text/plain;base64," + window.btoa(json);
+        link.click();
+      } else {
+        let blob = new Blob([json], { type: "text/plain" });
+        link.href = URL.createObjectURL(blob);
+        link.click();
+        URL.revokeObjectURL(link.href);
+      }
     });
   });
   dialog.find("#btnExportData").on("click", function (e) {


### PR DESCRIPTION
This should be working in Chrome, Firefox, and Safari. Instead of automatically downloading, it will generate the backup file and then present the user with a "Download" button. Depending on the browser settings, clicking the button may:
- in Chrome, open a file dialog allowing the user to select the save location
- in Firefox, download directly to the user's download folder (unless right-click/save as)
- in Safari on macOS, it pops up a blank window and asks the user for permission to allow the download, which then will attempt to open the text file in the preferred editor
- not tested on iOS
- the format of the backup file for the feature data has been updated to match that of the feature options, but the import will still work with the old format