### PR TITLE
updates to page and source previews

### DIFF
--- a/src/core/profileClasses.js
+++ b/src/core/profileClasses.js
@@ -210,9 +210,14 @@ export function ensureProfileClasses() {
         .addBack()
         .addClass(className)
         .each(function () {
-          // sometimes text can be put in the sources section, such as "See also:" (only happens with leading whitespace)
+          /*
+           * Sometimes unwrapped text can be rendered in the body, such as "See also:"
+           * (this seems to happen with leading whitespace or when templates/stickers are
+           * placed within text). Since there are no containers to wrap a section's content,
+           * we have to wrap the text nodes in a <span> tag so that the classes can be applied.
+           */
           if (this.previousSibling.nodeType == 3 && /\S/.test(this.previousSibling.nodeValue)) {
-            $(this.previousSibling).wrap('<p class="' + className + '"></p>');
+            $(this.previousSibling).wrap('<span class="' + className + '"></span>');
           }
         });
     });

--- a/src/features/sourcepreview/sourcepreview.css
+++ b/src/features/sourcepreview/sourcepreview.css
@@ -1,17 +1,33 @@
+.reference {
+  pointer-events: none;
+}
+.reference > a,
+.reference > .x-source-preview:not(.x-preview-hiding) {
+  pointer-events: auto;
+}
+
 .x-source-preview {
   position: absolute;
+  box-sizing: border-box;
+  display: block;
   z-index: 999;
-  -webkit-box-shadow: 3px 3px 12px 6px rgba(0, 0, 0, 0.3);
-  box-shadow: 3px 3px 12px 6px rgba(0, 0, 0, 0.3);
-  background-color: #fff;
-  border: 2px solid #ccc;
-  padding: 10px;
-  -webkit-border-radius: 1em;
-  -moz-border-radius: 1em;
-  border-radius: 1em;
   width: 450px;
+  margin-top: -0.8em;
   white-space: normal;
   font-size: 14px;
   font-style: normal;
   font-weight: normal;
+}
+
+.x-source-preview > div {
+  -webkit-box-shadow: 3px 3px 12px 6px rgba(0, 0, 0, 0.3);
+  box-shadow: 3px 3px 12px 6px rgba(0, 0, 0, 0.3);
+  background-color: #fff;
+  border: 2px solid #ccc;
+  margin-top: 1em;
+  padding: 10px;
+  -webkit-border-radius: 1em;
+  -moz-border-radius: 1em;
+  border-radius: 1em;
+  margin-top: 1em;
 }

--- a/src/features/sourcepreview/sourcepreview.js
+++ b/src/features/sourcepreview/sourcepreview.js
@@ -11,27 +11,35 @@ let removeBackReferences = true;
 
 function onHoverIn($element) {
   hideActivePreview();
-  let $popup = $('<div id="activeSourcePreview" class="x-source-preview" style="display: none;"></div>');
-
-  const citation = $element.closest(".reference").get(0);
-  const targetId = citation.id.replace("ref", "note").replace(/(_[0-9]+$)/g, "");
-  $popup.get(0).innerHTML = document.getElementById(targetId).innerHTML;
+  let x = $element.children("a").get(0).offsetLeft;
+  x = x < 425 ? 0 : x - 425;
+  let $popup = $(
+    '<div id="activeSourcePreview" class="x-source-preview" style="display: none; left: ' + x + 'px;"></div>'
+  );
+  const targetId = $element
+    .get(0)
+    .id.replace("ref", "note")
+    .replace(/(_[0-9]+$)/g, "");
+  $popup.append($("<div></div>").html(document.getElementById(targetId).innerHTML));
   if (removeBackReferences) {
     // remove back-reference links (based on readability.js:54)
-    $popup.contents().each(function () {
-      let el = $(this);
-      if (el.is(".a11y-back-ref, sup, a[href^='#_ref']:first-of-type, span:empty, a[name]:empty")) {
-        $(this).remove();
-        return true; // remove back-reference links
-      }
-      if (this.nodeValue && /^[*\s\u2191]*$/.test(this.nodeValue)) {
-        $(this).remove();
-        return true; // remove whitespace and the up arrow
-      }
-      return false;
-    });
+    $popup
+      .children()
+      .contents()
+      .each(function () {
+        let el = $(this);
+        if (el.is(".a11y-back-ref, sup, a[href^='#_ref']:first-of-type, span:empty, a[name]:empty")) {
+          $(this).remove();
+          return true; // remove back-reference links
+        }
+        if (this.nodeValue && /^[*\s\u2191]*$/.test(this.nodeValue)) {
+          $(this).remove();
+          return true; // remove whitespace and the up arrow
+        }
+        return false;
+      });
   }
-  $popup.appendTo(citation).fadeIn("fast");
+  $popup.appendTo($element).fadeIn("fast");
 }
 
 function hidePreview($element) {
@@ -44,7 +52,7 @@ function hidePreview($element) {
 }
 
 function onHoverOut($element) {
-  hidePreview($element.closest(".reference").find(".x-source-preview"));
+  hidePreview($element.closest(".reference").find(".x-source-preview").addClass("x-preview-hiding"));
 }
 
 function hideActivePreview() {
@@ -62,6 +70,7 @@ function attachHover(target) {
       }
       return false;
     })
+    .parent() // attach to the enclosing .reference, not the link itself
     .hoverDelay({
       delayIn: 500,
       delayOut: 0,

--- a/src/features/spacepreview/spacepreview.css
+++ b/src/features/spacepreview/spacepreview.css
@@ -1,5 +1,6 @@
 .x-page-preview {
   position: absolute;
+  left: 2%;
   z-index: 9999;
   background-color: #fff;
   border: 2px solid #ccc;
@@ -7,7 +8,8 @@
   -webkit-border-radius: 1em;
   -moz-border-radius: 1em;
   border-radius: 1em;
-  max-height: 450px;
+  max-width: min(98vw, 94%);
+  max-height: min(90vh, 450px);
   overflow: scroll !important;
   overflow-x: auto !important;
   color: #000;
@@ -55,14 +57,37 @@
   text-decoration: none !important;
 }
 
-.x-page-preview p.preview-links.first-of-many {
-  margin-bottom: 0;
-}
-.x-page-preview p.preview-links + p.preview-links {
+.x-page-preview .preview-header.box,
+.x-page-preview .preview-links.box {
+  float: right;
+  clear: right;
+  box-sizing: border-box;
+  padding: 0.75em;
+  margin: 0 0.25em 0.5em 0.25em;
   margin-top: 0;
+  max-width: max(50%, min(380px, 100%));
+}
+@media (max-width: 767px) {
+  .x-page-preview .preview-header.box,
+  .x-page-preview .preview-links.box {
+    min-width: 98%;
+  }
+}
+.x-page-preview .preview-links > p {
+  margin: 0 auto;
+}
+.x-page-preview .preview-links > p + p {
+  margin-top: 0.5em;
+}
+.x-page-preview .TAG {
+  line-height: 1.5;
 }
 
-.x-page-preview > .toc td > div > h2 {
+.x-page-preview > .toc {
+  margin-top: 1em;
+}
+.x-page-preview > .toc td > div > h2,
+.x-page-preview > .toc td > ul {
   margin-bottom: 0;
 }
 
@@ -76,12 +101,13 @@
 .x-page-preview:not(.show-scissors) > .preview-title button,
 .x-page-preview.show-title > .same-title,
 .x-page-preview:not(.show-header) > .preview-header,
-.x-page-preview:not(.show-audit) > .preview-audit,
+.x-page-preview:not(.show-audit) .preview-audit,
 .x-page-preview:not(.show-links) > .preview-links,
 .x-page-preview:not(.show-edit) .EDIT,
 .x-page-preview:not(.show-edit) .BLANK,
 .x-page-preview:not(.show-edit) .preview-links .SMALL,
 .x-page-preview:not(.show-edit) .editsection,
+.x-page-preview div[style*="clear:"][class*="preview-"]:empty,
 .x-page-preview > .toc .toctoggle,
 .x-page-preview:not(.expand-toc) > .toc td > div + ul,
 .x-page-preview:not(.show-toc) > .toc {
@@ -92,4 +118,10 @@
 .x-page-preview > br.preview-header {
   line-height: 0;
   visibility: hidden;
+}
+
+@media only print {
+  .x-page-preview {
+    display: none;
+  }
 }

--- a/src/features/spacepreview/spacepreview_options.js
+++ b/src/features/spacepreview/spacepreview_options.js
@@ -33,6 +33,12 @@ const pagePreviewFeature = {
           label: "Enable previews on category page links",
           defaultValue: false,
         },
+        {
+          id: "otherPagePreview",
+          type: OptionType.CHECKBOX,
+          label: "Enable previews on special page links (Help, Projects, etc.)",
+          defaultValue: false,
+        },
       ],
     },
     {
@@ -55,7 +61,7 @@ const pagePreviewFeature = {
         {
           id: "showHeader",
           type: OptionType.CHECKBOX,
-          label: "Show header (date, location, tags/surnames)",
+          label: "Show header information (date, location, tags/surnames)",
           defaultValue: true,
         },
         {


### PR DESCRIPTION
- updated page preview window to always load from the left side of the page for maximum space
- added option for Help, Project, and Special pages to page preview
- format category links and header fields into floating rounded boxes in space page previews
- updated source preview to place it underneath the citation link and allow clicking/selecting inside the window
- fix bug introduced on certain malformed profiles when wrapping text in a paragraph tag (changed to span)
