### PR TITLE
fixed Safari detection for backup downloads

### DIFF
--- a/src/options.js
+++ b/src/options.js
@@ -656,11 +656,13 @@ function wrapBackupData(key, data) {
 
 function getBackupLink(wrappedJsonData) {
   let link = document.createElement("a");
+  link.title = 'Right-click to "Save as..." at specific location on your device.';
   let json = JSON.stringify(wrappedJsonData);
-  if (/(?=.*\bSafari\b)(?!.*\b(Chrome|Firefox)\b).*/.test(navigator.userAgent)) {
+  if (/^((?!\b(Chrome|Firefox)\/).)*(?=\bSafari\/)/.test(navigator.userAgent)) {
     // Safari doesn't handle blobs or the download attribute properly
     link.href = "data:application/octet-stream;base64," + window.btoa(json);
     link.target = "_blank";
+    link.title = link.title.replace("Save as...", "Download Linked File As...");
   } else {
     let blob = new Blob([json], { type: "text/plain" });
     link.href = URL.createObjectURL(blob);


### PR DESCRIPTION
As mentioned on G2G:
https://www.wikitree.com/g2g/1490020/have-you-seen-the-wikitree-browser-extension?show=1578812#c1578812