### PR TITLE
1.5 bug fixes

### DIFF
--- a/public/main.css
+++ b/public/main.css
@@ -7,7 +7,7 @@ html {
 
 body {
   /* override the injected stylesheet from Chrome which is percentage-based to match the root size */
-  font-family: "Open Sans", Helvetica, Arial, sans-serif;
+  font-family: "Segoe UI", "Open Sans", Helvetica, Arial, sans-serif;
   font-size: 1rem;
   /* override Safari's semi-transparent background */
   background-color: #fff;

--- a/src/features/readability/readability_options.js
+++ b/src/features/readability/readability_options.js
@@ -232,7 +232,7 @@ const readabilityFeature = {
         {
           id: "removeSourceLabels",
           type: OptionType.SELECT,
-          label: "Remove bold labels (and leading asterisks) from the beginning of sources",
+          label: "Remove bold labels and asterisks from the beginning of sources",
           values: [
             {
               value: 0,

--- a/src/features/sticky_header/sticky_header.css
+++ b/src/features/sticky_header/sticky_header.css
@@ -1,5 +1,6 @@
 :root {
   --header-height: 60px;
+  --header-sub-height: 0px;
 }
 
 @media screen {
@@ -10,11 +11,11 @@
   }
 
   .sticky-header .wrapper {
-    --header-offset: calc(20px + var(--header-height));
+    --header-offset: calc(20px + var(--header-height) + var(--header-sub-height));
   }
 
   .sticky-header .qa-body-wrapper {
-    --header-offset: calc(14px + var(--header-height));
+    --header-offset: calc(14px + var(--header-height) + var(--header-sub-height));
   }
 
   .sticky-header a[name],
@@ -25,7 +26,7 @@
   .sticky-header .wrapper #header,
   .sticky-header .qa-body-wrapper .qa-header {
     position: fixed;
-    z-index: 2147000000;
+    z-index: 9555555; /* above GEDCOMpare (99999) but below compare draft modal (9999999) */
     top: 0;
     height: var(--header-height);
     background: none;

--- a/src/features/sticky_header/sticky_header.js
+++ b/src/features/sticky_header/sticky_header.js
@@ -7,6 +7,7 @@ import { checkIfFeatureEnabled } from "../../core/options/options_storage";
 
 async function initStickyHeader() {
   let headerHeight = $("#header, .qa-header").first().css("height");
+  let subHeight = $(".qa-nav-sub").first().css("height");
   if (headerHeight) {
     document.documentElement.style.setProperty("--header-height", headerHeight);
     if (!$("body").is(".home")) {
@@ -17,6 +18,9 @@ async function initStickyHeader() {
         window.location.hash = hash;
       }
     }
+  }
+  if (subHeight) {
+    document.documentElement.style.setProperty("--header-sub-height", subHeight);
   }
 }
 

--- a/src/features/what_links_here/what_links_here.js
+++ b/src/features/what_links_here/what_links_here.js
@@ -33,9 +33,7 @@ async function whatLinksHereSection() {
           getProfile($(this).text(), undefined, "WBE_what_links_here").then((person) => {
             window.whatLinksHereSReponses++;
             if (person?.Name) {
-              let thisWikiLink = $(
-                `<a href="http://www.wikitree.com/wiki/${person.Name}">${displayName(person)[0]}</a>`
-              );
+              let thisWikiLink = $(`<a href="/wiki/${person.Name}">${displayName(person)[0]}</a>`);
               window.whatLinksHereS.push(thisWikiLink);
             }
             if (window.whatLinksHereSReponses == window.whatLinksHereSRequests) {
@@ -72,9 +70,7 @@ async function whatLinksHereSection() {
           });
         } else {
           window.whatLinksHereS.push(
-            $(
-              `<a href="https://www.wikitree.com/wiki/${$(this).attr("href").split("/wiki/")[1]}">${$(this).text()}</a>`
-            )
+            $(`<a href="/wiki/${$(this).attr("href").split("/wiki/")[1]}">${$(this).text()}</a>`)
           );
         }
       });
@@ -103,7 +99,7 @@ async function whatLinksHereLink() {
   if (dLink != "") {
     // Add the link
     const newLi = $(
-      `<li><a class="pureCssMenui whatLinksHere" href="https://www.wikitree.com/index.php?title=Special:Whatlinkshere/${dLink}&limit=1000" title="See what links to this page" id="whatLinksHere">What Links Here</li>`
+      `<li><a class="pureCssMenui whatLinksHere" href="/index.php?title=Special:Whatlinkshere/${dLink}&limit=1000" title="See what links to this page" id="whatLinksHere">What Links Here</li>`
     );
     newLi.insertAfter(findMatchesLi.parent());
   }

--- a/src/options.js
+++ b/src/options.js
@@ -656,11 +656,13 @@ function wrapBackupData(key, data) {
 
 function getBackupLink(wrappedJsonData) {
   let link = document.createElement("a");
+  link.title = 'Right-click to "Save as..." at specific location on your device.';
   let json = JSON.stringify(wrappedJsonData);
-  if (/(?=.*\bSafari\b)(?!.*\b(Chrome|Firefox)\b).*/.test(navigator.userAgent)) {
+  if (/^((?!\b(Chrome|Firefox)\/).)*(?=\bSafari\/)/.test(navigator.userAgent)) {
     // Safari doesn't handle blobs or the download attribute properly
     link.href = "data:application/octet-stream;base64," + window.btoa(json);
     link.target = "_blank";
+    link.title = link.title.replace("Save as...", "Download Linked File As...");
   } else {
     let blob = new Blob([json], { type: "text/plain" });
     link.href = URL.createObjectURL(blob);


### PR DESCRIPTION
Several bug fixes cherry-picked from development:
- fixed Safari detection for backup downloads
- remove absolute links from What Links Here (to fix person profile previews)
- fixed G2G overlap when tabs are shown below the header; fixed z-index conflict with modal for compare draft feature
- very minor style tweaks to the options window