### PR TITLE
bug fixes for Page Previews

### DIFF
--- a/src/features/spacepreview/spacepreview.css
+++ b/src/features/spacepreview/spacepreview.css
@@ -17,6 +17,13 @@
   font-weight: normal;
   text-decoration: none;
 }
+dialog .x-page-preview {
+  position: fixed;
+  left: 20%;
+  top: 40%;
+  max-width: min(75vw, 70%);
+  max-height: min(50vh, 450px);
+}
 
 .x-page-preview .EDIT,
 .x-page-preview .editsection {

--- a/src/features/spacepreview/spacepreview.js
+++ b/src/features/spacepreview/spacepreview.js
@@ -104,7 +104,7 @@ function populateCategoryPreview($popup, url) {
 
 function addCloseButton($popup) {
   $popup.prepend(
-    $('<a href="#" class="x-preview-close">&#x2716;</a>')
+    $('<a href="#" class="x-preview-close" title="Click here to close this preview window">&#x2716;</a>')
       .on("auxclick", function (e) {
         e.stopPropagation();
         e.preventDefault();
@@ -148,6 +148,10 @@ function attachHover(target) {
     $(target)
       .find(selectors)
       .filter(function () {
+        // do not apply to links in the menus/header/footer (like Help)
+        if ($(this).closest("#header").length > 0 || $(this).closest("#footer").length > 0) {
+          return false;
+        }
         // make sure each element is only wired up once
         if (!this.xHasSpaceHover) {
           // don't wire up space previews inside other space preview windows
@@ -187,7 +191,7 @@ async function initFeature() {
 
   // intercept clicks outside of the preview to close it
   $(document).on("click", function (event) {
-    if ($(event.target).closest("#spacePreview").length === 0) {
+    if ($(event.target).closest("#activePagePreview").length === 0) {
       hideActivePreview();
     }
   });


### PR DESCRIPTION
- don't enable previews in the header/menus/footer
- don't close preview window when clicking inside it
- fixed placement of category previews when inside the modal category finder