### PR TITLE
some fixes from Murray's testing on Safari

### DIFF
--- a/public/main.css
+++ b/public/main.css
@@ -31,7 +31,7 @@ a:active {
   color: #8ec641;
   text-decoration: none;
 }
-a:hover {
+a:not(.nohover):hover {
   text-decoration: none;
   background: #ffe270;
 }

--- a/src/content.js
+++ b/src/content.js
@@ -61,3 +61,8 @@ import "./features/debugProfileClasses/debugProfileClasses";
 import "./core/editToolbar";
 
 //createTopMenu();
+
+(function (runtime) {
+  const manifest = runtime.getManifest();
+  console.log(manifest.name + " " + manifest.version + " is accessing this page.");
+})(chrome.runtime);

--- a/src/features/categoryDisplay/categoryDisplay.js
+++ b/src/features/categoryDisplay/categoryDisplay.js
@@ -54,10 +54,25 @@ async function moveCategories() {
   switch (options.categoryLocation) {
     case "sidebar":
       $("#categories").find('span[class="SMALL"]').remove();
-      if ($('a[name="DNA"').length >= 2) {
-        $('a[name="DNA"').last().before($("#categories"));
+      let $sidebar = $(".columns.six").first();
+      if ($sidebar.length > 0) {
+        // space pages don't have a DNA section, so we just need to find the first section element
+        $sidebar.find("div > span.large").first().closest("div").before($("#categories"));
+        // if it's in list form (with no border box)...
+        $("#categories:not(.box) > ol")
+          // ... reformat the heading match the rest of the sidebar ...
+          .closest("div")
+          .removeAttr("style")
+          .prepend('<div class="large" style="margin-bottom:0.5em"><strong>Categories</strong></div>')
+          .children("ol")
+          .first()
+          .contents()
+          .each(function (index, element) {
+            if (element.nodeType === 1 && element.nodeName === "LI") return false;
+            $(element).remove(); // ... and remove the "Categories:" link and content before the list items
+          });
       } else {
-        $('a[name="DNA"').before($("#categories"));
+        $('a[name="DNA"]').last().before($("#categories"));
       }
       break;
     case "top":

--- a/src/features/categoryDisplay/categoryDisplay_options.js
+++ b/src/features/categoryDisplay/categoryDisplay_options.js
@@ -2,7 +2,7 @@
 Created By: Steve Harris (Harris-5439)
 */
 
-import { isProfilePage } from "../../core/pageType";
+import { isProfilePage, isSpacePage } from "../../core/pageType";
 import { registerFeature, OptionType } from "../../core/options/options_registry.js";
 
 const categoryDisplay = {
@@ -13,7 +13,7 @@ const categoryDisplay = {
   creators: [{ name: "Steve Harris", wikitreeid: "Harris-5439" }],
   contributors: [],
   defaultValue: false,
-  pages: [isProfilePage],
+  pages: [isProfilePage, isSpacePage],
   options: [
     {
       id: "categoryLocation",

--- a/src/options.js
+++ b/src/options.js
@@ -5,11 +5,19 @@ import "./features/register_feature_options";
 import { isWikiTreeUrl } from "./core/common";
 import { restoreOptions, restoreData } from "./upload";
 
-$("h1").prepend($("<img src='" + chrome.runtime.getURL("images/wikitree-small.png") + "'>"));
-
 (function (runtime) {
   const manifest = runtime.getManifest();
-  console.log("Options for " + manifest.name + " " + manifest.version);
+  const title = manifest.name + " " + manifest.version;
+  console.log("Options for " + title);
+  $("head > title").text(title.replace("Extension", "Extension Options"));
+  $("#h1Text").attr("title", title);
+  $("h1").prepend(
+    $(
+      '<a href="https://www.wikitree.com/" target="_blank" class="nohover" title="WikiTree: Where genealogists collaborate"><img src="' +
+        runtime.getURL("images/wikitree-small.png") +
+        '" border="0" alt="WikiTree: Where genealogists collaborate" /></a>'
+    )
+  );
 })(chrome.runtime);
 
 // Categories

--- a/src/options.js
+++ b/src/options.js
@@ -7,6 +7,11 @@ import { restoreOptions, restoreData } from "./upload";
 
 $("h1").prepend($("<img src='" + chrome.runtime.getURL("images/wikitree-small.png") + "'>"));
 
+(function (runtime) {
+  const manifest = runtime.getManifest();
+  console.log("Options for " + manifest.name + " " + manifest.version);
+})(chrome.runtime);
+
 // Categories
 const categories = ["Global", "Profile", "Editing", "Style"];
 // If a new feature is added with a new category, add the category to the list


### PR DESCRIPTION
- update categoryDisplay to work on space pages
  - formatted to match sidebar sections if in list mode
- add the extension name/version to various places for easier testing
  - console.log
  - hover on "Extension Options" header
  - options page title (in full tab mode)
- link to WikiTree from the main header logo