### PR TITLE
resolved a couple of style conflicts with the base site

### DIFF
--- a/src/features/spacepreview/spacepreview.css
+++ b/src/features/spacepreview/spacepreview.css
@@ -17,6 +17,7 @@
   font-style: normal;
   font-weight: normal;
   text-decoration: none;
+  text-align: left;
 }
 
 /* special handling for previews on pins inside WT+ modal dialogs and autocomplete suggestions */

--- a/src/features/sticky_header/sticky_header.css
+++ b/src/features/sticky_header/sticky_header.css
@@ -32,6 +32,14 @@
     background: none;
   }
 
+  /* the preview container and content for merges by WikiTree needs to be adjusted if sticky header is used */
+  .sticky-header #previewContainer {
+    z-index: 9999999;
+  }
+  .sticky-header #previewContainer #previewContent {
+    top: calc(var(--header-offset) + 20px) !important;
+  }
+
   .sticky-header .qa-body-wrapper .qa-header {
     width: 940px;
     background-color: #fff;


### PR DESCRIPTION
- sticky header was overlapping the preview window on the merge page, which had a z-index of 5002 and was positioned only 20px from the top of the page
- page previews on links that are in a center-aligned element (captions on images centered by a table cell, the [Ranger badge](https://www.wikitree.com/index.php?title=Special:Badges&b=ranger) page) had to be forced back to left-alignment