### PR TITLE
enhancements and bug fixes

### DIFF
--- a/public/options.css
+++ b/public/options.css
@@ -43,7 +43,6 @@
 }
 .feature-options {
   font-size: 16px;
-  font-weight: 300;
 }
 div.feature-options {
   padding-top: 10px;
@@ -65,7 +64,7 @@ div.feature-options {
 }
 .section:not(.feature-enabled) > .section-content > div.feature-options::before,
 .section:not(.feature-enabled) > .section-content > dialog.feature-options > .dialog-content::before {
-  display: inline-block;
+  display: table;
   content: "This feature must be toggled on for these options to take effect.";
   border: 3px solid #fbb616;
   font-size: 14px;

--- a/src/features/printerfriendly/printerfriendly.css
+++ b/src/features/printerfriendly/printerfriendly.css
@@ -60,6 +60,8 @@
   .print-content-only #commentG2GDiv,
   .print-content-only #header,
   .print-content-only #showHideDescendants,
+  .print-content-only #ancestorTreeContainer,
+  .print-content-only #descendantsContainer,
   .print-content-only #categories,
   .print-content-only #toc,
   .print-content-only #whatLinksHereSection,

--- a/src/features/readability/readability.css
+++ b/src/features/readability/readability.css
@@ -82,7 +82,8 @@ sup.reference {
     visibility: visible;
   }
 
-  .hide-sidebar .x-sidebar {
+  .collapse-sidebar-if-empty .x-sidebar.no-visible-content,
+  .collapse-sidebar .x-sidebar {
     display: none !important;
   }
 

--- a/src/features/readability/readability.js
+++ b/src/features/readability/readability.js
@@ -501,9 +501,9 @@ async function initReadability() {
         if (!startExpanded && !!window.location.hash) {
           let target = document.getElementById(window.location.hash.substring(1));
           if (!target) {
-            target = document.getElementsByName(window.location.hash.substring(1));
-            if (target.length > 0) {
-              target = target[0];
+            let byName = document.getElementsByName(window.location.hash.substring(1));
+            if (byName.length > 0) {
+              target = byName[0];
             }
           }
           if (target && $(target).closest(".section-" + sectionLower).length > 0) {

--- a/src/features/readability/readability.js
+++ b/src/features/readability/readability.js
@@ -11,8 +11,6 @@ import $ from "jquery";
 import { shouldInitializeFeature, getFeatureOptions } from "../../core/options/options_storage.js";
 import { ensureProfileClasses } from "../../core/profileClasses";
 
-export let toggleReadingMode;
-
 async function initReadability() {
   ensureProfileClasses();
   const options = await getFeatureOptions("readability");
@@ -344,14 +342,14 @@ async function initReadability() {
     }
   }
   // toggle hidden elements (either always or in reading mode only)
-  let initToggleOptions = true;
-  toggleReadingMode = function () {
+  function setHiddenElements(toggleValue) {
+    const isReadingMode = !!(toggleValue !== undefined ? toggleValue : options.readingMode_toggle);
     let isToggled = function (option, flags) {
       let alwaysFlag = ((flags || 0) ^ 0x7e) | 0x81; // negate the flag bits and set the always and reading bits
       let readingFlag = (flags || 0) | 1; // set the reading bit
       if (option) {
-        if (initToggleOptions) {
-          return option % 256 === alwaysFlag || (options.readingMode_toggle && option % 128 === readingFlag);
+        if (toggleValue === undefined) {
+          return option % 256 === alwaysFlag || (isReadingMode && option % 128 === readingFlag);
         } else {
           return option % 256 === readingFlag;
         }
@@ -369,10 +367,6 @@ async function initReadability() {
     }
     if (isToggled(options.removeBackReferences)) {
       $("html").toggleClass("hide-src-back");
-    }
-    if (isToggled(options.hideSidebar)) {
-      $("html").toggleClass("hide-sidebar");
-      $(".x-sidebar").prev().toggleClass("ten").toggleClass("sixteen");
     }
     if (isToggled(options.hideSidebarStatus)) {
       $("html").toggleClass("hide-sidebar-status");
@@ -401,8 +395,8 @@ async function initReadability() {
       collapsibleSections.forEach(function (section) {
         let sectionLower = section.toLowerCase();
         if (options["collapse" + section] / 1 === 254) {
-          if (initToggleOptions) {
-            // this turns the toggle button on, but it starts out as expanded instead of collapsed (see below)
+          if (toggleValue === undefined) {
+            // this displays the toggle button at initialization, but it will start expanded instead of collapsed (see toggleSection below)
             $("html").toggleClass("collapse-" + sectionLower);
           }
         } else if (isToggled(options["collapse" + section])) {
@@ -460,8 +454,41 @@ async function initReadability() {
     if (isToggled(options.hideBackground)) {
       $("html").toggleClass("hide-background");
     }
-    initToggleOptions = false;
-  };
+    // this needs to take place after all of the other elements are toggled (to check for visible children)
+    if (options.hideSidebar / 1 > 0) {
+      let $sb = $(".x-sidebar");
+      if (isToggled(options.hideSidebar, 2)) {
+        $("html").toggleClass("collapse-sidebar-if-empty");
+      } else if (isToggled(options.hideSidebar)) {
+        $("html").toggleClass("collapse-sidebar");
+        $sb.prev().toggleClass("ten").toggleClass("sixteen");
+      }
+      if (options.hideSidebar / 1 === 3 || options.hideSidebar / 1 === 253) {
+        $sb.removeClass("no-visible-content");
+        // wait for the CSS to apply so that we can determine visibility
+        window.setTimeout(function () {
+          if (
+            $sb.children(":visible").filter(function () {
+              // some elements may technically be visible but have no content, like anchors and #geneticfamily
+              return !!$(this).html();
+            }).length === 0
+          ) {
+            $sb.addClass("no-visible-content");
+          } else {
+            $sb.removeClass("no-visible-content");
+          }
+          // wait for the no-visible-content class to be applied
+          window.setTimeout(function () {
+            if (!$sb.is(":visible")) {
+              $sb.prev().addClass("sixteen").removeClass("ten");
+            } else {
+              $sb.prev().removeClass("sixteen").addClass("ten");
+            }
+          }, 0);
+        }, 0);
+      }
+    }
+  }
 
   (function (collapsibleSections) {
     collapsibleSections.forEach(function (section) {
@@ -513,7 +540,7 @@ async function initReadability() {
     bgStyle.text(bgStyle.text().replace(/\b(BODY\s*{)/is, "html:not(.hide-background) $1"));
   }
 
-  toggleReadingMode();
+  setHiddenElements(); // initialize with the saved setting
 
   // this only controls whether the toggle button for reading mode is on the screen
   if (options.readingMode) {
@@ -539,7 +566,7 @@ async function initReadability() {
         '><label for="reading_mode_checkbox">Reading Mode</label>'
     );
     toggleElement.find("input").on("change", function () {
-      toggleReadingMode();
+      setHiddenElements(this.checked);
       setToggleValue(this.checked);
     });
     // add the toggle button at the top of the page content

--- a/src/features/readability/readability_options.js
+++ b/src/features/readability/readability_options.js
@@ -345,67 +345,7 @@ const readabilityFeature = {
             {
               id: "hideSidebar",
               type: OptionType.SELECT,
-              label: "Collapse the entire sidebar (and extend the content to full-width)",
-              values: [
-                {
-                  value: 0,
-                  text: "never",
-                },
-                {
-                  value: 1,
-                  text: "in reading mode",
-                },
-                {
-                  value: 255,
-                  text: "always",
-                },
-              ],
-              defaultValue: 1,
-            },
-            {
-              id: "hideSidebarStatus",
-              type: OptionType.SELECT,
-              label: "Hide status blocks (like project protected) from the sidebar",
-              values: [
-                {
-                  value: 0,
-                  text: "never",
-                },
-                {
-                  value: 1,
-                  text: "in reading mode",
-                },
-                {
-                  value: 255,
-                  text: "always",
-                },
-              ],
-              defaultValue: 0,
-            },
-            {
-              id: "hideForumPosts",
-              type: OptionType.SELECT,
-              label: "Hide G2G forum posts in the sidebar",
-              values: [
-                {
-                  value: 0,
-                  text: "never",
-                },
-                {
-                  value: 1,
-                  text: "in reading mode",
-                },
-                {
-                  value: 255,
-                  text: "always",
-                },
-              ],
-              defaultValue: 0,
-            },
-            {
-              id: "hideDNAConnections",
-              type: OptionType.SELECT,
-              label: "Hide DNA connections in the sidebar",
+              label: "Collapse and extend the content to full-width",
               values: [
                 {
                   value: 0,
@@ -428,12 +368,80 @@ const readabilityFeature = {
                   text: "always",
                 },
               ],
-              defaultValue: 0,
+              defaultValue: 3,
+            },
+            {
+              id: "hideSidebarStatus",
+              type: OptionType.SELECT,
+              label: "Hide status blocks (like project protected)",
+              values: [
+                {
+                  value: 0,
+                  text: "never",
+                },
+                {
+                  value: 1,
+                  text: "in reading mode",
+                },
+                {
+                  value: 255,
+                  text: "always",
+                },
+              ],
+              defaultValue: 1,
+            },
+            {
+              id: "hideForumPosts",
+              type: OptionType.SELECT,
+              label: "Hide G2G forum posts",
+              values: [
+                {
+                  value: 0,
+                  text: "never",
+                },
+                {
+                  value: 1,
+                  text: "in reading mode",
+                },
+                {
+                  value: 255,
+                  text: "always",
+                },
+              ],
+              defaultValue: 1,
+            },
+            {
+              id: "hideDNAConnections",
+              type: OptionType.SELECT,
+              label: "Hide DNA connections",
+              values: [
+                {
+                  value: 0,
+                  text: "never",
+                },
+                {
+                  value: 1,
+                  text: "in reading mode",
+                },
+                {
+                  value: 3,
+                  text: "in reading mode when empty",
+                },
+                {
+                  value: 253,
+                  text: "always when empty",
+                },
+                {
+                  value: 255,
+                  text: "always",
+                },
+              ],
+              defaultValue: 1,
             },
             {
               id: "hideSidebarImages",
               type: OptionType.SELECT,
-              label: "Hide popular images in the sidebar",
+              label: "Hide popular images",
               values: [
                 {
                   value: 0,
@@ -448,12 +456,12 @@ const readabilityFeature = {
                   text: "always",
                 },
               ],
-              defaultValue: 0,
+              defaultValue: 1,
             },
             {
               id: "hideCollaborationLinks",
               type: OptionType.SELECT,
-              label: "Hide collaboration links in the sidebar",
+              label: "Hide collaboration links",
               values: [
                 {
                   value: 0,
@@ -468,12 +476,12 @@ const readabilityFeature = {
                   text: "always",
                 },
               ],
-              defaultValue: 0,
+              defaultValue: 1,
             },
             {
               id: "hideResearch",
               type: OptionType.SELECT,
-              label: "Hide the research section in the sidebar",
+              label: "Hide the research section",
               values: [
                 {
                   value: 0,
@@ -488,7 +496,7 @@ const readabilityFeature = {
                   text: "always",
                 },
               ],
-              defaultValue: 0,
+              defaultValue: 1,
             },
           ],
         },

--- a/src/features/sticky_header/sticky_header.js
+++ b/src/features/sticky_header/sticky_header.js
@@ -13,9 +13,23 @@ async function initStickyHeader() {
     if (!$("body").is(".home")) {
       $("html").addClass("sticky-header");
       if (window.location.hash) {
-        let hash = window.location.hash;
-        window.location.hash = "";
-        window.location.hash = hash;
+        let target = document.getElementById(window.location.hash.substring(1));
+        if (!target) {
+          let byName = document.getElementsByName(window.location.hash.substring(1));
+          if (byName.length > 0) {
+            target = byName[0];
+          }
+          if (!target) {
+            if (window.location.hash == "#Ancestors") {
+              target = document.getElementById("ancestorTreeContainer");
+            } else if (window.location.hash == "#Descendants") {
+              target = document.getElementById("descendantsContainer");
+            }
+          }
+        }
+        if (target) {
+          target.scrollIntoView({ behavior: "smooth", block: "start" });
+        }
       }
     }
   }


### PR DESCRIPTION
- added "on empty" options to allow collapsing the sidebar when no elements are visible
- fixed scrolling/history issue from https://www.wikitree.com/g2g/1480572/wikitree-hacktoberfest-2022-testing-and-feedback-requests?show=1593190#c1593190
- hide ancestors/descendants on printer friendly bio since there is already a printer-friendly tree option