### PR TITLE
SaveButtonsStyleOptions

### DIFF
--- a/src/content.js
+++ b/src/content.js
@@ -54,6 +54,7 @@ import "./features/date_fixer/date_fixer";
 import "./features/language_setting/language_setting";
 import "./features/locationsHelper/locationsHelper";
 import "./features/make_radio_buttons_deselectable/make_radio_buttons_deselectable";
+import "./features/save_buttons_style_options/save_buttons_style_options";
 import "./features/sticky_toolbar/sticky_toolbar";
 // BioCheck needs to load later than custom_change_summary_options
 import "./features/bioCheck/bioCheck";

--- a/src/features/register_feature_options.js
+++ b/src/features/register_feature_options.js
@@ -71,6 +71,7 @@ import "./printerfriendly/printerfriendly_options";
 import "./randomProfile/randomProfile_options";
 import "./readability/readability_options";
 import "./redir_ext_links/redir_ext_links_options";
+import "./save_buttons_style_options/save_buttons_style_options_options";
 import "./sourcepreview/sourcepreview_options";
 import "./spacepreview/spacepreview_options";
 import "./table_filters/table_filters_options";

--- a/src/features/save_buttons_style_options/save_buttons_style_options.css
+++ b/src/features/save_buttons_style_options/save_buttons_style_options.css
@@ -1,0 +1,4 @@
+#saveButtons p a:first-child,
+.six.columns #saveButtons button:first-child {
+  margin-bottom: 10px;
+}

--- a/src/features/save_buttons_style_options/save_buttons_style_options.js
+++ b/src/features/save_buttons_style_options/save_buttons_style_options.js
@@ -1,0 +1,33 @@
+/*
+Created By: Ian Beacall (Beacall-6)
+*/
+import $ from "jquery";
+import { shouldInitializeFeature, getFeatureOptions } from "../../core/options/options_storage";
+
+shouldInitializeFeature("saveButtonsStyleOptions").then((result) => {
+  if (result) {
+    import("./save_buttons_style_options.css");
+    changeLinksToButtons();
+  }
+});
+
+async function changeLinksToButtons() {
+  const container = $("#deleteDraftLinkContainer").closest("div");
+  container.prop("id", "saveButtons");
+  const spans = container.find("span");
+  spans.each(function () {
+    const link = $(this).find("a");
+    link.addClass("button");
+    $(this).html("").append(link);
+  });
+  const options = await getFeatureOptions("saveButtonsStyleOptions");
+  if (options.buttonSize === "allSmall") {
+    container.find("a,button").each(function () {
+      $(this).addClass("small");
+    });
+  } else if (options.buttonSize === "halfSmall") {
+    container.find("p a").each(function () {
+      $(this).addClass("small");
+    });
+  }
+}

--- a/src/features/save_buttons_style_options/save_buttons_style_options_options.js
+++ b/src/features/save_buttons_style_options/save_buttons_style_options_options.js
@@ -1,0 +1,30 @@
+/*
+Created By: Ian Beacall (Beacall-6)
+*/
+
+import { registerFeature, OptionType } from "../../core/options/options_registry";
+import { isProfileEdit } from "../../core/pageType";
+
+registerFeature({
+  name: "Save Buttons Style Options",
+  id: "saveButtonsStyleOptions",
+  description: "Turns the Compare and Return links in the Save section on the Edit page into buttons.",
+  category: "Editing/Edit_Profile",
+  creators: [{ name: "Ian Beacall", wikitreeid: "Beacall-6" }],
+  contributors: [],
+  defaultValue: false,
+  pages: [isProfileEdit],
+  options: [
+    {
+      id: "buttonSize",
+      type: OptionType.RADIO,
+      label: "Button Size",
+      values: [
+        { value: "allSmall", text: "All Small" },
+        { value: "halfSmall", text: "Small Compare and Return Buttons" },
+        { value: "large", text: "All Large" },
+      ],
+      defaultValue: "helfSmall",
+    },
+  ],
+});


### PR DESCRIPTION
Turns the Compare and Return links in the Save section on the Edit page into buttons. Gives options for big or small buttons.