### PR TITLE
scissors: add use link for categories

### DIFF
--- a/src/features/scissors/scissors.js
+++ b/src/features/scissors/scissors.js
@@ -16,6 +16,7 @@ import {
   isTemplatePage,
   isProjectPage,
   isNetworkFeed,
+  isCategoryEdit,
 } from "../../core/pageType";
 
 shouldInitializeFeature("scissors").then((result) => {
@@ -104,7 +105,7 @@ async function helpScissors() {
     copyItems.push({ label: "URL", text: aUrl });
   }
 
-  if (isCategoryPage) {
+  if (isCategoryPage || isCategoryEdit) {
     const aTitle = document.title.trim();
     const aLink = `[[${aTitle}]]`;
     copyItems.push({ label: "Use", text: aLink });

--- a/src/features/scissors/scissors_options.js
+++ b/src/features/scissors/scissors_options.js
@@ -1,5 +1,13 @@
 import { registerFeature, OptionType } from "../../core/options/options_registry";
-import { isProfileEdit, isSpaceEdit, isWikiPage, isProfileHistoryDetail, isNetworkFeed } from "../../core/pageType";
+import {
+  isProfileEdit,
+  isSpaceEdit,
+  isWikiPage,
+  isProfileHistoryDetail,
+  isNetworkFeed,
+  isCategoryPage,
+  isCategoryEdit,
+} from "../../core/pageType";
 
 registerFeature({
   name: "Scissors",
@@ -13,7 +21,15 @@ registerFeature({
     { name: "Aleš Trtnik", wikitreeid: "Trtnik-2" },
   ],
   defaultValue: true,
-  pages: [isWikiPage, isProfileEdit, isSpaceEdit, isProfileHistoryDetail, isNetworkFeed],
+  pages: [
+    isWikiPage,
+    isProfileEdit,
+    isSpaceEdit,
+    isProfileHistoryDetail,
+    isNetworkFeed,
+    isCategoryEdit,
+    isCategoryPage,
+  ],
   options: [
     {
       id: "removeDates",


### PR DESCRIPTION
- only "use" works, but that's all I need anyway
- no clue how it worked before when isCategoryPage was not referenced in scissors_options.js