### PR TITLE
Ensure sibling and children counts are always at the end of their family list

### DIFF
--- a/src/features/change_family_lists/change_family_lists.js
+++ b/src/features/change_family_lists/change_family_lists.js
@@ -1332,14 +1332,10 @@ function textNodesUnder(el) {
 async function addChildrenCount() {
   if ($("#childrenCount").length == 0) {
     const siblingLength = $(".VITALS span[itemprop='sibling']").length;
-    $("<span id='siblingCount'>[" + siblingLength + "]</span>").insertAfter(
-      $(".VITALS span[itemprop='sibling']").eq(siblingLength - 1)
-    );
+    $("#siblingDetails").append($("<span id='siblingCount'>[" + siblingLength + "]</span>"));
 
     const childrenLength = $(".VITALS span[itemprop='children']").length;
-    $("<span id='childrenCount'>[" + childrenLength + "]</span>").insertAfter(
-      $(".VITALS span[itemprop='children']").eq(childrenLength - 1)
-    );
+    $("#childrenDetails").append($("<span id='childrenCount'>[" + childrenLength + "]</span>"));
   }
 }
 


### PR DESCRIPTION
Previously, when the list sibling was a half-sibling, the [half] indicator would appear after the sibling count when vertical lists were not selected.