### PR TITLE
G2G links to answers and comments with preview in Discord and others

### DIFF
--- a/src/features/g2g/g2g.js
+++ b/src/features/g2g/g2g.js
@@ -106,6 +106,24 @@ function linkify() {
   });
 }
 
+function replacePermaLinks() {
+  const allAnchorNodes = document.getElementsByTagName("a");
+  for (let i = 0; i < allAnchorNodes.length; i++) {
+    //https://www.wikitree.com/g2g/1652303/join-the-2nd-germany-research-party-on-wikitree-day?show=1657604#a1657604
+
+    const indexShow = allAnchorNodes[i].href.indexOf("show=");
+
+    if (indexShow > -1) {
+      //console.log(allAnchorNodes[i].href);
+      const indexHash = allAnchorNodes[i].href.indexOf("#");
+      const indexAfterHashAndAorC = indexHash + 2;
+      const number = allAnchorNodes[i].href.substring(indexAfterHashAndAorC);
+      const plainURL = window.location.href.split("?")[0];
+      allAnchorNodes[i].href = "https://apps.wikitree.com/apps/straub620/g2gpeek.php?post=" + plainURL + "&a=" + number;
+    }
+  }
+}
+
 async function initG2G() {
   const options = await getFeatureOptions("g2g");
   if (options.checkMarks) {
@@ -138,6 +156,9 @@ async function initG2G() {
   }
   if (options.linkify) {
     linkify();
+  }
+  if (options.previewLinks) {
+    replacePermaLinks();
   }
 }
 

--- a/src/features/g2g/g2g_options.js
+++ b/src/features/g2g/g2g_options.js
@@ -76,6 +76,12 @@ const g2g = {
       label: "Turn WikiTree IDs into links to the profiles",
       defaultValue: true,
     },
+    {
+      id: "previewLinks",
+      type: OptionType.CHECKBOX,
+      label: "Make links to answers and comments show preview when shared on Discord",
+      defaultValue: false,
+    },
   ],
 };
 


### PR DESCRIPTION
Before and after comparison:

![grafik](https://github.com/wikitree/wikitree-browser-extension/assets/12448283/9db697da-7d22-4ade-85c1-f946ed899e72)
