### PR TITLE
G2G links with preview only for actual question pages

### DIFF
--- a/src/features/g2g/g2g.js
+++ b/src/features/g2g/g2g.js
@@ -158,7 +158,10 @@ async function initG2G() {
     linkify();
   }
   if (options.previewLinks) {
-    replacePermaLinks();
+    const questionURL = window.location.toString().match(/https:\/\/www\.wikitree\.com\/g2g\/\d+\//);
+    if (questionURL != null) {
+      replacePermaLinks();
+    }
   }
 }
 


### PR DESCRIPTION
else it breaks the links on e.g. https://www.wikitree.com/g2g/following