### PR TITLE
Correct relationship name in absence of gender

### DIFF
--- a/src/features/distanceAndRelationship/distanceAndRelationship.js
+++ b/src/features/distanceAndRelationship/distanceAndRelationship.js
@@ -327,14 +327,17 @@ function doRelationshipText(userID, profileID) {
               .replace(/siblings/, "sibling");
           }
           if (out.match(/nephew|niece/)) {
-            if (profileGender == "male") {
-              out = out.replace(/nephew|niece/, "uncle");
-            }
-            if (profileGender == "female") {
-              out = out.replace(/nephew|niece/, "aunt");
-            }
-            if (out.match(/(uncle|aunt) or.*/)) {
-              out = out.split(" or ")[0];
+            if (out.match(/(nephew|niece) or (nephew|niece)/)) {
+              out = out.replace(/nephew/, "uncle");
+              out = out.replace(/niece/, "aunt");
+            } else {
+              if (profileGender == "male") {
+                out = out.replace(/nephew|niece/, "uncle");
+              } else if (profileGender == "female") {
+                out = out.replace(/nephew|niece/, "aunt");
+              } else {
+                out = out.replace(/nephew|niece/, "uncle or aunt");
+              }
             }
           }
           if (


### PR DESCRIPTION
See https://www.wikitree.com/g2g/1684413/incorrect-relationship-wikitree-extensions-relationship

This change only affects nephew/niece cases where either one of the profiles does not have a gender. The wording "...uncle or aunt" or "...nephew or niece" will be used depending on the situation.