### PR TITLE
Shareable Sources: bullets without newline separation

### DIFF
--- a/src/features/shareable_sources/shareable_sources.js
+++ b/src/features/shareable_sources/shareable_sources.js
@@ -403,8 +403,17 @@ function basicSourcesArray(bio) {
       // Split sources section into bits
       let sourcesBits = sourcesSection.split(/\n{2,}/);
 
-      // Handle ** sources by merging with previous
       for (let i = sourcesBits.length - 1; i >= 0; i--) {
+        // Splitting sources without empty line between them
+        const splitSourceBits = sourcesBits[i].trim().split("\n*");
+        if (splitSourceBits.length > 1) {
+          sourcesBits[i] = splitSourceBits[0];
+          for (let j = 1; j < splitSourceBits.length; j++) {
+            sourcesBits.splice(i + j, 0, splitSourceBits[j]);
+          }
+        }
+
+        // Handle ** sources by merging with previous
         if (sourcesBits[i].trim().startsWith("**")) {
           sourcesBits[i - 1] += "\n" + sourcesBits[i];
           sourcesBits.splice(i, 1);
@@ -415,6 +424,7 @@ function basicSourcesArray(bio) {
       for (let source of sourcesBits) {
         if (source.trim()) {
           source = source.replace(/^\*/g, "").trim();
+          console.log("pushing " + source);
           sources.push(source);
         }
       }

--- a/src/features/shareable_sources/shareable_sources.js
+++ b/src/features/shareable_sources/shareable_sources.js
@@ -424,7 +424,6 @@ function basicSourcesArray(bio) {
       for (let source of sourcesBits) {
         if (source.trim()) {
           source = source.replace(/^\*/g, "").trim();
-          console.log("pushing " + source);
           sources.push(source);
         }
       }


### PR DESCRIPTION
So far only tested with https://www.wikitree.com/index.php?title=Kaiser-4116, where I first saw the problem:

![YQ2W92wlu2SF0nEa](https://github.com/wikitree/wikitree-browser-extension/assets/12448283/5de999cc-5755-4cf0-9a1e-1013150e74c5)
