### PR TITLE
fix build warnings about Node and iOS versions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,11 +6,11 @@ on:
 jobs:
   latest-release:
     name: "Latest Release"
-    runs-on: "macos-latest"
+    runs-on: macos-14
 
     steps:
       - name: Check out code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Set release flags based on branch
         run: |
           echo "X_SHORT_HASH=`git rev-parse --short HEAD`" >> $GITHUB_ENV
@@ -22,9 +22,9 @@ jobs:
           # build number is the number of seconds since 2023-08-01 UTC
           echo "X_SAFARI_BUILD=$((`date -u +%s`+300000000-1690848000))" >> $GITHUB_ENV
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
-          node-version: 16.x
+          node-version: 20.x
           cache: "npm"
       - name: Install dependencies
         run: npm ci
@@ -147,13 +147,17 @@ jobs:
           [ ! -f dist-safari-macos.pkg ] || mv dist-safari-macos.pkg wbe-${{ env.X_RELEASE_TAG }}-${{ env.X_VERSION }}-${{ env.X_SHORT_HASH }}-safari-macos.pkg
           [ ! -f dist-safari-macos.zip ] || mv dist-safari-macos.zip wbe-${{ env.X_RELEASE_TAG }}-${{ env.X_VERSION }}-${{ env.X_SHORT_HASH }}-safari-macos.zip
       - name: Update release
-        uses: "marvinpinto/action-automatic-releases@6273874b61ebc8c71f1a61b2d98e234cf389b303"
+        uses: ncipollo/release-action@v1
         with:
-          repo_token: "${{ secrets.GITHUB_TOKEN }}"
+          token: "${{ secrets.GITHUB_TOKEN }}"
           prerelease: ${{ env.X_RELEASE_TAG != 'stable' }}
-          files: |
+          artifacts: |
             wbe-*.zip
             wbe-*.ipa
             wbe-*.pkg
-          automatic_release_tag: "${{ (env.X_RELEASE_TAG == 'stable' || env.X_RELEASE_TAG == 'preview') && env.X_RELEASE_TAG || format('release-{0}', github.ref_name) }}"
-          title: ${{ env.X_RELEASE_TAG }}-${{ env.X_VERSION }}
+          tag: "${{ (env.X_RELEASE_TAG == 'stable' || env.X_RELEASE_TAG == 'preview') && env.X_RELEASE_TAG || format('release-{0}', github.ref_name) }}"
+          name: ${{ env.X_RELEASE_TAG }}-${{ env.X_VERSION }}
+          generateReleaseNotes: true
+          allowUpdates: true
+          removeArtifacts: true
+          replacesArtifacts: true


### PR DESCRIPTION
Hopefully this will fix the build warnings for a while. I replaced marvinpinto/action-automatic-releases with ncipollo/release-action@v1 and updated to the newer versions of the GitHub actions and Node.js:
https://github.com/marvinpinto/action-automatic-releases/pull/2
https://github.com/rerun-io/rerun/pull/1466

I also updated it to use the macos-14 environment instead of macos-latest, which still apparently uses macos-12. This should enable it to build with the latest Xcode. I did not submit it to Apple, but others indicated that fixed their problem:
https://forums.developer.apple.com/forums/thread/747459

I was able to run it on my own repository successfully except for that I had disabled the automatic uploading to Apple.