### PR TITLE
fix build warnings about Node and iOS versions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,11 +6,11 @@ on:
 jobs:
   latest-release:
     name: "Latest Release"
-    runs-on: "macos-latest"
+    runs-on: macos-14
 
     steps:
       - name: Check out code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Set release flags based on branch
         run: |
           echo "X_SHORT_HASH=`git rev-parse --short HEAD`" >> $GITHUB_ENV
@@ -22,9 +22,9 @@ jobs:
           # build number is the number of seconds since 2023-08-01 UTC
           echo "X_SAFARI_BUILD=$((`date -u +%s`+300000000-1690848000))" >> $GITHUB_ENV
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
-          node-version: 16.x
+          node-version: 20.x
           cache: "npm"
       - name: Install dependencies
         run: npm ci
@@ -147,13 +147,17 @@ jobs:
           [ ! -f dist-safari-macos.pkg ] || mv dist-safari-macos.pkg wbe-${{ env.X_RELEASE_TAG }}-${{ env.X_VERSION }}-${{ env.X_SHORT_HASH }}-safari-macos.pkg
           [ ! -f dist-safari-macos.zip ] || mv dist-safari-macos.zip wbe-${{ env.X_RELEASE_TAG }}-${{ env.X_VERSION }}-${{ env.X_SHORT_HASH }}-safari-macos.zip
       - name: Update release
-        uses: "marvinpinto/action-automatic-releases@6273874b61ebc8c71f1a61b2d98e234cf389b303"
+        uses: ncipollo/release-action@v1
         with:
-          repo_token: "${{ secrets.GITHUB_TOKEN }}"
+          token: "${{ secrets.GITHUB_TOKEN }}"
           prerelease: ${{ env.X_RELEASE_TAG != 'stable' }}
-          files: |
+          artifacts: |
             wbe-*.zip
             wbe-*.ipa
             wbe-*.pkg
-          automatic_release_tag: "${{ (env.X_RELEASE_TAG == 'stable' || env.X_RELEASE_TAG == 'preview') && env.X_RELEASE_TAG || format('release-{0}', github.ref_name) }}"
-          title: ${{ env.X_RELEASE_TAG }}-${{ env.X_VERSION }}
+          tag: "${{ (env.X_RELEASE_TAG == 'stable' || env.X_RELEASE_TAG == 'preview') && env.X_RELEASE_TAG || format('release-{0}', github.ref_name) }}"
+          name: ${{ env.X_RELEASE_TAG }}-${{ env.X_VERSION }}
+          generateReleaseNotes: true
+          allowUpdates: true
+          removeArtifacts: true
+          replacesArtifacts: true


### PR DESCRIPTION
Assuming all goes well with the PR in development (https://github.com/wikitree/wikitree-browser-extension/pull/536), this also needs to be applied to the stable branch. I made a separate commit to avoid merging issues.