### PR TITLE
Add key controls to the clipboard and notes 

### DIFF
--- a/src/features/clipboard_and_notes/clipboard_and_notes.css
+++ b/src/features/clipboard_and_notes/clipboard_and_notes.css
@@ -140,6 +140,10 @@
   background: rgb(221, 250, 218);
 }
 
+#clipboard .clipping.clip-unselected {
+  background: #FFF !important;
+}
+
 #clipboard[data-type="clipboard"] .clipping:active {
   font-weight: bold;
 }

--- a/src/features/clipboard_and_notes/clipboard_and_notes.css
+++ b/src/features/clipboard_and_notes/clipboard_and_notes.css
@@ -131,6 +131,7 @@
   cursor: default;
 }
 
+#clipboard .clipping.clip-selected,
 #clipboard .clipping:hover {
   background: rgb(221, 250, 218);
 }

--- a/src/features/clipboard_and_notes/clipboard_and_notes.css
+++ b/src/features/clipboard_and_notes/clipboard_and_notes.css
@@ -285,3 +285,7 @@ body.qa-body-js-on .deleteClippingButton {
   padding: 0.2em;
   margin: 0;
 }
+
+.qa-body-wrapper td.clipping pre {
+  margin-top: 0 !important;
+}

--- a/src/features/clipboard_and_notes/clipboard_and_notes.css
+++ b/src/features/clipboard_and_notes/clipboard_and_notes.css
@@ -17,6 +17,10 @@
   background: white;
   display: none;
   resize: both;
+  user-select: none; /* CSS3 (little to no support) */
+  -ms-user-select: none; /* IE 10+ */
+  -moz-user-select: none; /* Gecko (Firefox) */
+  -webkit-user-select: none; /* Webkit (Safari, Chrome) */
 }
 
 #clipboard.label {

--- a/src/features/clipboard_and_notes/clipboard_and_notes.js
+++ b/src/features/clipboard_and_notes/clipboard_and_notes.js
@@ -632,8 +632,6 @@ async function clipboard(type, e, action = false) {
         $(`#tab-list .tab[data-groupkey="${activeTab}"] .tab-name`).trigger("click");
       }
     };
-    //focus on clipboard, so keys won't be caught by textarea
-    window.location.hash = "clipboard";
   };
 }
 

--- a/src/features/clipboard_and_notes/clipboard_and_notes.js
+++ b/src/features/clipboard_and_notes/clipboard_and_notes.js
@@ -92,8 +92,8 @@ function groupNameFromInput() {
   return $("#groupInput").val().trim();
 }
 
-function currentActiveTabFor(type) {
-  return localStorage[`clipboard_${type}_active_tab`];
+function activeTabVarNameFor(type) {
+  return `clipboard_${type}_active_tab`;
 }
 
 function focusOnGroup(group) {
@@ -335,7 +335,7 @@ function placeClipboard(aClipboard, event) {
 
 async function clipboard(type, e, action = false) {
   clippingRow = -1;
-  let activeTab = localStorage[currentActiveTabFor(type)] || "";
+  let activeTab = localStorage[activeTabVarNameFor(type)] || "";
   if ($("#clipboard").length) {
     activeTab = $("#tab-list .tab.active").data("groupkey");
     $("#clipboard #clippings").html("");
@@ -860,7 +860,7 @@ function showGroup($tab) {
 
   // Show the active tab content
   const groupKey = $tab.data("groupkey") || "";
-  localStorage.setItem(currentActiveTabFor($("#clipboard").data("type")), groupKey);
+  localStorage.setItem(activeTabVarNameFor($("#clipboard").data("type")), groupKey);
   $("#clippings div").hide();
   const groupDiv = $(`#clippings div[data-groupkey="${groupKey}"]`);
   $("#groupInput").val(original2real(groupDiv.data("group")));

--- a/src/features/clipboard_and_notes/clipboard_and_notes.js
+++ b/src/features/clipboard_and_notes/clipboard_and_notes.js
@@ -644,16 +644,24 @@ function keyUpListener(e) {
   if (!$("#clipboard").is(":visible")) return; // and only if the clipboard is visible
   if ($("input, textarea").is(":focus")) return; // and no text input area has the focus
 
-  if (e.code === "ArrowUp" || e.code === "ArrowDown") {
+  if (["ArrowDown", "ArrowUp", "PageUp", "PageDown"].includes(e.code)) {
     e.preventDefault();
     e.stopPropagation();
     const clippings = $(".clipping:visible");
     if (clippingRow >= 0 && clippingRow < clippings.length) clippings.eq(clippingRow).removeClass("clip-selected");
-    if (e.code === "ArrowDown") {
-      clippingRow = ++clippingRow % clippings.length;
-    } else if (e.code === "ArrowUp") {
-      --clippingRow;
-      if (clippingRow < 0) clippingRow = clippings.length - 1;
+    switch (e.code) {
+      case "ArrowDown":
+        clippingRow = ++clippingRow % clippings.length;
+        break;
+      case "ArrowUp":
+        --clippingRow;
+        if (clippingRow < 0) clippingRow = clippings.length - 1;
+        break;
+      case "PageUp":
+        clippingRow = Math.max(clippingRow - 5, 0);
+        break;
+      case "PageDown":
+        clippingRow = Math.min(clippingRow + 5, clippings.length - 1);
     }
     const selectedRow = clippings.eq(clippingRow);
     selectedRow.addClass("clip-selected");

--- a/src/features/clipboard_and_notes/clipboard_and_notes.js
+++ b/src/features/clipboard_and_notes/clipboard_and_notes.js
@@ -57,7 +57,7 @@ shouldInitializeFeature("clipboardAndNotes").then((result) => {
 });
 
 function decodeHTMLEntities(text) {
-  var textArea = document.createElement("textarea");
+  const textArea = document.createElement("textarea");
   textArea.innerHTML = text;
   return textArea.value;
 }
@@ -602,7 +602,7 @@ async function clipboard(type, e, action = false) {
                   e.preventDefault();
                   editClipping(key, type, e);
 
-                  var word = "clipping";
+                  let word = "clipping";
                   if (type == "notes") {
                     word = "note";
                   }

--- a/src/features/clipboard_and_notes/clipboard_and_notes.js
+++ b/src/features/clipboard_and_notes/clipboard_and_notes.js
@@ -632,6 +632,8 @@ async function clipboard(type, e, action = false) {
         $(`#tab-list .tab[data-groupkey="${activeTab}"] .tab-name`).trigger("click");
       }
     };
+    //focus on clipboard, so keys won't be caught by textarea
+    window.location.hash = "clipboard";
   };
 }
 

--- a/src/features/locationsHelper/locationsHelper.js
+++ b/src/features/locationsHelper/locationsHelper.js
@@ -14,6 +14,7 @@ const vocEnd = new Date("1795-09-17");
 const bataviaStart = new Date("1803-02-21");
 const capeColonyStart = new Date("1806-01-19");
 const colonyEnd = new Date("1910-05-31");
+const newSAStart = new Date("1994-04-27");
 // Transvaal
 const tRepStart = new Date("1844-04-09");
 const boerRepStart = new Date("1852-01-17");
@@ -90,17 +91,14 @@ function highlightSearchWords(activeEl, dText, innerBit) {
   // And match the parts of the text in the location box (#mBirthLocation, etc.) against dText and wrap <span class="autocomplete-suggestion-term"> around them.
   const theLocation = $("#" + activeEl.id);
   const theLocationText = theLocation.val();
-  const theLocationTextMatch = theLocationText.match(/[A-z]+/g);
+  const theLocationTextMatch = theLocationText.match(/[A-z']+/g);
   if (theLocationTextMatch != null) {
     theLocationTextMatch.forEach(function (aWord) {
       if (dText.match(aWord) != null) {
         const theMatch = dText.match(aWord)[0];
         const theMatchRegex = new RegExp(theMatch, "g");
         innerBit.html(
-          innerBit
-            .html()
-            .trim()
-            .replace(theMatchRegex, '<span class="autocomplete-suggestion-term">' + theMatch + "</span>")
+          innerBit.html().trim().replace(theMatchRegex, `<span class="autocomplete-suggestion-term">${theMatch}</span>`)
         );
       }
     });
@@ -561,6 +559,15 @@ async function locationsHelper() {
                   .replace("Cape of Good Hope", "Cape of Good Hope Colony")
                   .replace("Cabo de Goede Hoop", "Cape of Good Hope Colony")
                   .replace("Cape Colony", "Cape of Good Hope Colony");
+              } else if (theDate >= colonyEnd && theDate < newSAStart) {
+                dText = dText
+                  .replace("Cabo de Goede Hoop", "Cape Province, South Africa")
+                  .replace("Cape Colony", "Cape Province, South Africa");
+              } else if (theDate >= newSAStart) {
+                dText = dText
+                  .replace("Cabo de Goede Hoop", "Western Cape, South Africa")
+                  .replace("Cape Colony", "Western Cape, South Africa")
+                  .replace("Cape Province, South Africa", "Western Cape, South Africa");
               }
 
               // Transvaal
@@ -593,6 +600,8 @@ async function locationsHelper() {
                   .replace("Oranje Unie", "Oranjerivierkolonie");
               } else if (theDate >= boerColonyStart && theDate < colonyEnd) {
                 dText = dText.replace("Orange Free State, South Africa", "Oranje Unie");
+              } else if (theDate >= newSAStart) {
+                dText = dText.replace("Orange Free State, South Africa", "Free State, South Africa");
               }
 
               // Natal


### PR DESCRIPTION
Shift-left/right moves between tabs
Shift=up/down selects the previous/next clipping on the active tab
Shift-enter copies the current selected clipping to the document and closes the clipboard
Shift-PageUp: select the clipping 5 positions up or the first one
Shift-PageDown: select the clipping 5 positions down, or the last one

Also:
Fixed formatting issue in cliboard on g2g pages.
Improvements to location helper for South Africa.
Fixed bug in location helper when location contains an apostrophe.
