### PR TITLE
Hotfix: Category Management after search update

### DIFF
--- a/src/features/add_person/add_person.js
+++ b/src/features/add_person/add_person.js
@@ -349,8 +349,10 @@ function moveCategories() {
       bottom += "\n" + parts[i];
     }
   }
-  ta.value = top.substring(1) + "\n" + bottom.substring(1);
-  if (oldValue != ta.value) {
-    document.getElementById("wpSummary").value = "Moving categories. ";
+  if (top != "") {
+    ta.value = top.substring(1) + bottom;
+    if (oldValue != ta.value) {
+      document.getElementById("wpSummary").value = "Moving categories. ";
+    }
   }
 }

--- a/src/features/category_management/category_management.js
+++ b/src/features/category_management/category_management.js
@@ -893,7 +893,7 @@ function HackMergeCheckboxes() {
       cbs[i].classList.add("profile_selector");
       cbs[i].name = "cb" + i;
       cbs[i].id = "cb" + i;
-      cbs[i].nextSibling.remove();
+      //cbs[i].nextSibling.remove();
     }
   }
   //remove merge controls and annotations


### PR DESCRIPTION
- fix missing checkboxes in Category Management for search results after introduction of search result table
- fix additional trailing newline during profile creation without any categories