### PR TITLE
Cleanup the CC7 deltas DB

### DIFF
--- a/src/features/clipboard_and_notes/clipboard_and_notes.js
+++ b/src/features/clipboard_and_notes/clipboard_and_notes.js
@@ -617,7 +617,7 @@ async function clipboard(type, e, action = false) {
           }
           $("#clipboard #clippings").after($("<p>You have no " + word + ".  You can add one below.</p>"));
         }
-        // Make the tabs re-ordable
+        // Make the tabs re-orderable
         const tabList = $("#tab-list");
         if (tabList.find(".tab").length > 1) {
           tabList.sortable({


### PR DESCRIPTION
We remove empty deltas and ones older than 45 days (unless they are the most recent ones for their user). We also show all deltas (previously ones with >500 additions were ignored), but will only show the first 500 items in each.

Future enhancement: provide the user with a way to see all of a large set (perhaps an additional pop-up that only shows it).