### PR TITLE
Usability Tweaks: forward to space page after saving

### DIFF
--- a/src/features/usability_tweaks/usability_tweaks.js
+++ b/src/features/usability_tweaks/usability_tweaks.js
@@ -10,6 +10,7 @@ import {
   isSpecialTrustedList,
   isProfilePage,
   isSpecialMyConnections,
+  isSpacePage,
 } from "../../core/pageType";
 import "./usability_tweaks.css";
 import { shouldInitializeFeature, getFeatureOptions } from "../../core/options/options_storage";
@@ -261,6 +262,13 @@ function removeMe() {
   }
 }
 
+function forwardToSavedSpagePage() {
+  const greenBoxes = document.getElementsByClassName("status green");
+  if (greenBoxes.length == 1 && greenBoxes[0].innerText.indexOf("Changes Saved.") > -1) {
+    window.location = window.location;
+  }
+}
+
 shouldInitializeFeature("usabilityTweaks").then((result) => {
   if (result) {
     getFeatureOptions("usabilityTweaks").then((options) => {
@@ -454,6 +462,10 @@ shouldInitializeFeature("usabilityTweaks").then((result) => {
       if (options.removeMeButton && isSpecialTrustedList) {
         removeMe();
       }
-    });
+
+      if (isSpacePage && options.leaveSpaceEditAfterSave) {
+        forwardToSavedSpagePage();
+      }
+    }); //getFeatureOptions
   }
 });

--- a/src/features/usability_tweaks/usability_tweaks.js
+++ b/src/features/usability_tweaks/usability_tweaks.js
@@ -263,9 +263,29 @@ function removeMe() {
 }
 
 function forwardToSavedSpagePage() {
-  const greenBoxes = document.getElementsByClassName("status green");
-  if (greenBoxes.length == 1 && greenBoxes[0].innerText.indexOf("Changes Saved.") > -1) {
-    window.location = window.location;
+  const boxClass = "status green";
+  const greenBoxes = document.getElementsByClassName(boxClass);
+  const searchParams = new URLSearchParams(window.location.search);
+  const savedParam = "saveRedir";
+
+  if (
+    greenBoxes.length == 1 &&
+    greenBoxes[0].innerText.indexOf("Changes Saved." > -1) &&
+    !searchParams.has(savedParam)
+  ) {
+    searchParams.append(savedParam, "WBE");
+    window.location.search = searchParams;
+  } else if (searchParams.has(savedParam)) {
+    //make sure, scissors are loaded first
+    var delayInMilliseconds = 300;
+    setTimeout(function () {
+      const div = document.createElement("div");
+      div.className = boxClass;
+      div.style.marginTop = "1em";
+      div.innerHTML =
+        "<span class='larger'>Changes Saved.</span> This redirect was proudly brought to you by the <a href='https://www.wikitree.com/wiki/Space:WikiTree_Browser_Extension'>WikiTree Browser Extension</a>.";
+      document.getElementsByTagName("h1")[0].appendChild(div);
+    }, delayInMilliseconds);
   }
 }
 

--- a/src/features/usability_tweaks/usability_tweaks_options.js
+++ b/src/features/usability_tweaks/usability_tweaks_options.js
@@ -64,6 +64,19 @@ const usabilityTweaks = {
       ],
     },
     {
+      id: "editSpacePage",
+      type: OptionType.GROUP,
+      label: "Free Space Pages",
+      options: [
+        {
+          id: "leaveSpaceEditAfterSave",
+          type: OptionType.CHECKBOX,
+          label: "Leave edit view after saving",
+          defaultValue: true,
+        },
+      ],
+    },
+    {
       id: "myConnections",
       type: OptionType.GROUP,
       label: "My Connections",


### PR DESCRIPTION
After saving a Free Space page, it will show a box that it was saved, but won't redirect on the profile page afterwards:
![grafik](https://github.com/wikitree/wikitree-browser-extension/assets/12448283/c9a37e89-7cc8-4775-a341-f50fb92377db)

With this tweak, it will:
![grafik](https://github.com/wikitree/wikitree-browser-extension/assets/12448283/fe429db8-b04b-40d3-af7a-91bc083bd1a0)

Question is: should we make it default, like it currently is in the code?