### PR TITLE
fix null reference error when no lastCatSpan is set

### DIFF
--- a/src/features/category_management/category_management.js
+++ b/src/features/category_management/category_management.js
@@ -267,8 +267,10 @@ function AddCategoryChangeLinksOnProfile(categoryDiv) {
   addLink.accessKey = "k";
   addLink.title = "Add a category to this profile";
   AddAddReplaceEventHandler(addLink, lastCatSpan, profileId, "");
-  lastCatSpan.append(" ");
-  lastCatSpan.appendChild(addLink);
+  if (lastCatSpan) {
+    lastCatSpan.append(" ");
+    lastCatSpan.appendChild(addLink);
+  }
 }
 
 function IsProfileEditable() {


### PR DESCRIPTION
Seems to be caused when the Category Display feature and the Category Management feature are used simultaneously.