### PR TITLE
Backup and restore enhancements

### DIFF
--- a/public/main.css
+++ b/public/main.css
@@ -49,6 +49,9 @@ h1 {
 }
 
 /* Modal dialogs */
+#showAlertDialog {
+  font-size: 16px;
+}
 dialog {
   max-width: 100vw;
   max-height: 100vh;
@@ -64,6 +67,7 @@ dialog::backdrop {
 }
 dialog > .dialog-content {
   box-sizing: border-box;
+  width: fit-content;
   max-width: 90vw;
   max-height: 80vh;
   margin-top: 31px;

--- a/public/options.css
+++ b/public/options.css
@@ -282,19 +282,19 @@ h1 .toggle-category {
   color: #999;
   text-decoration: none;
 }
-#settingsDialog ul {
+#settingsDialog .dialog-content ul {
   list-style: none;
   margin: 0;
   padding: 0;
 }
-#settingsDialog li {
+#settingsDialog .dialog-content li {
   margin-top: 10px;
 }
-#settingsDialog li:first-child {
+#settingsDialog .dialog-content li:first-child {
   margin-top: 0;
 }
-#settingsDialog button,
-#settingsDialog a.button {
+#settingsDialog .dialog-content button,
+#settingsDialog .dialog-content a.button {
   display: inline-block;
   background-color: #ddd;
   color: #000;
@@ -306,21 +306,21 @@ h1 .toggle-category {
   font-size: 16px;
   text-decoration: none;
 }
-#settingsDialog button:hover,
-#settingsDialog a.button:hover {
+#settingsDialog .dialog-content button:hover,
+#settingsDialog .dialog-content a.button:hover {
   background-color: #8fc641;
   color: #000;
   cursor: pointer;
 }
-#settingsDialog button:active,
-#settingsDialog a.button:active {
+#settingsDialog .dialog-content button:active,
+#settingsDialog .dialog-content a.button:active {
   color: #000;
   box-shadow: 0;
 }
-#settingsDialog a.button.download,
-#settingsDialog a.button.download:active {
+#settingsDialog .dialog-content a.button.download,
+#settingsDialog .dialog-content a.button.download:active {
   background-color: #ffe270;
 }
-#settingsDialog a.button.download:hover {
+#settingsDialog .dialog-content a.button.download:hover {
   background-color: #8fc641;
 }

--- a/src/core/common.js
+++ b/src/core/common.js
@@ -596,16 +596,16 @@ export function extensionContextInvalidatedCheck(error) {
 }
 
 chrome.runtime.onMessage.addListener(function (request, sender, sendResponse) {
-  if (request && request.greeting) {
-    if (request.greeting === "backupData") {
+  if (request && request.action) {
+    if (request.action === "backupData") {
       backupData(sendResponse);
-    } else if (request.greeting === "restoreData") {
-      restoreData(request.data, sendResponse);
+    } else if (request.action === "restoreData") {
+      restoreData(request.payload, sendResponse);
     } else {
-      sendResponse({ nak: `unexpected greeting ${request.greeting}` });
+      sendResponse({ nak: "UNKNOWN_ACTION", action: request.action });
     }
   } else {
-    sendResponse({ nak: "unexpected request" });
+    sendResponse({ nak: "INVALID_MESSAGE" });
   }
   return true; // potentially prevent the "The message port closed before a response was received." error
 });

--- a/src/options.js
+++ b/src/options.js
@@ -6,7 +6,7 @@ import "./features/register_feature_options";
 import { WBE, isWikiTreeUrl, showAlert, wrapBackupData, getBackupLink } from "./core/common";
 import { restoreOptions, restoreData, sendMessageToContentTab } from "./upload";
 import { navigatorDetect } from "./core/navigatorDetect";
-import { shouldInitializeFeature, getFeatureOptions } from "./core/options/options_storage.js";
+import { shouldInitializeFeature } from "./core/options/options_storage.js";
 
 shouldInitializeFeature("darkMode").then((result) => {
   if (result) {
@@ -419,7 +419,7 @@ function addOptionsForFeature(featureData, optionsContainerElement, options) {
 }
 
 // when the options page loads, load status of options from storage into the UI elements
-$(document).ready(() => {
+$(() => {
   restore_options();
 });
 

--- a/src/upload.js
+++ b/src/upload.js
@@ -5,6 +5,7 @@ export function openFileChooser(readerCallback, readAs = "text") {
   if (window.FileReader) {
     let chooser = document.createElement("input");
     chooser.type = "file";
+    chooser.accept = "text/plain";
     chooser.addEventListener("change", function (e) {
       if (chooser.files && chooser.files.length > 0) {
         let reader = new FileReader();
@@ -40,7 +41,7 @@ export function restoreOptions(onProcessing) {
       } else {
         let isValid = false;
         try {
-          let json = JSON.parse(this.result);
+          const json = JSON.parse(this.result);
           if (
             (isValid = json.extension && json.extension.indexOf("WikiTree Browser Extension") === 0 && json.features)
           ) {
@@ -49,7 +50,9 @@ export function restoreOptions(onProcessing) {
               resolve();
             });
           }
-        } catch {}
+        } catch {
+          /* if JSON parsing failed or some other error, isValid will still be false here */
+        }
         if (!isValid) {
           reject({ nak: "INVALID_FORMAT", content: this.result });
         }
@@ -85,7 +88,9 @@ export function restoreData(onProcessing) {
               }
             });
           }
-        } catch {}
+        } catch {
+          /* if JSON parsing failed or some other error, isValid will still be false here */
+        }
         if (!isValid) {
           reject({ nak: "INVALID_FORMAT", content: this.result });
         }
@@ -99,7 +104,7 @@ export function sendMessageToContentTab(message, callback) {
   async function _trySendMessageAsync(tabs, message, callback, index) {
     if (tabs && tabs.length && index < tabs.length) {
       const tab = tabs[index];
-      if (tab && tab.url && isWikiTreeUrl(tab.url) && tab.id) {
+      if (tab && tab.url && isWikiTreeUrl(tab.url) && tab.status == "complete" && tab.id) {
         chrome.tabs.sendMessage(tab.id, message, function (response) {
           if (chrome.runtime.lastError) {
             _trySendMessageAsync(tabs, message, callback, index + 1); // try the next tab


### PR DESCRIPTION
These are my changes to the backup/restore process. It handles the cross-tab messaging in a more stable way. It will try each WikiTree tab sequentially, and if one fails to receive the message, it will move to the next one. Additional error messages have also been added.

Some additional changes related to Riel's save-restore branch have also been merged in, but this PR excludes any changes to the file format, the indexedDB tables, and the semaphore fix.

The semaphore may not be needed. The bug appears to be that common.js is loading twice ONLY on the Special:Home page, and that was causing the issue. I have not tracked that down yet.