### PR TITLE
DateFixer: do not recognize umlauts as word end / South Africa Historic Places migration categories

### DIFF
--- a/src/features/date_fixer/date_fixer.js
+++ b/src/features/date_fixer/date_fixer.js
@@ -183,7 +183,7 @@ function handleDateInput(dateString, inputElement) {
   }
 
   // Detect if the date string has an ambiguous month abbreviation
-  const ambiguousMonthMatch = dateString.match(/\b(Ju|J|M|Ma|A)\b/i);
+  const ambiguousMonthMatch = dateString.match(/.*(Ju|J|M|Ma|A)(\s|\.|-)/i);
   if (ambiguousMonthMatch) {
     const possibleMonths = getAmbiguousMonths(ambiguousMonthMatch[0]);
     return displayClarificationModal(dateString, ambiguousMonthMatch[0], inputElement, possibleMonths);
@@ -556,7 +556,7 @@ function fixDates() {
     }
 
     // Check for ambiguous month abbreviations
-    const ambiguousMonthMatch = input.match(/\b(Ju|J|M|Ma|A)\b/i);
+    const ambiguousMonthMatch = input.match(/.*(Ju|J|M|Ma|A)(\s|\.|-)/i);
     if (ambiguousMonthMatch) {
       console.log("Found ambiguous month abbreviation:", ambiguousMonthMatch[0]);
 

--- a/src/features/migration_category_helper/entities.js
+++ b/src/features/migration_category_helper/entities.js
@@ -296,6 +296,8 @@ export const entities = {
     "Free and Hanseatic City of Hamburg",
     "Free and Hanseatic City of Lübeck",
   ],
+  "German Confederation/German Empire/Holy Roman Empire (delete two)": ["Württemberg" /* wrong, but heavily used*/],
+
   "German Democratic Republic (East Germany)": [
     "Rostock District",
     "Schwerin District",
@@ -478,6 +480,14 @@ export const entities = {
     "Glasgow",
   ],
 
+  "South Africa, Historic Places": [
+    "Cape Colony",
+    "Dutch Cape Colony",
+    "Free State pre 1910" /* currently no migration categories*/,
+    "Natal pre 1910" /* currently no migration categories*/,
+    "South West Africa 1915-1990" /* currently no migration categories*/,
+    "Transvaal pre 1910",
+  ],
   Sweden: [
     "Blekinge County",
     "Gothenburg and Bohus County",

--- a/src/features/migration_category_helper/migration_category_helper.js
+++ b/src/features/migration_category_helper/migration_category_helper.js
@@ -34,16 +34,16 @@ async function CreateMigrationCategory(tb) {
     countryFrom = getRightFromWord("from ", fromPart);
     entityFrom = getRightFromWord("from ", fromPart);
   } else if (cat.indexOf("Emigrants") > -1) {
-    countryFrom = getLeftFromComma(cat);
-    entityFrom = getLeftFromComma(cat);
+    countryFrom = getLeftFromWord(", Emigrants", cat);
+    entityFrom = getLeftFromWord(", Emigrants", cat);
 
     if (cat.indexOf(" to ") > -1) {
       countryTo = getRightFromWord("to ", cat);
       entityTo = getRightFromWord("to ", cat);
     }
   } else if (cat.indexOf("Immigrants") > -1) {
-    countryTo = getLeftFromComma(cat);
-    entityTo = getLeftFromComma(cat);
+    countryTo = getLeftFromWord(", Immigrants", cat);
+    entityTo = getLeftFromWord(", Immigrants", cat);
     if (cat.indexOf(" from ") > -1) {
       countryFrom = getRightFromWord("from ", cat);
       entityFrom = getRightFromWord("from ", cat);
@@ -156,6 +156,11 @@ function getLeftFromComma(cat) {
 function getRightFromWord(word, cat) {
   const indexWord = cat.indexOf(word) + word.length;
   return cat.substring(indexWord).trim();
+}
+
+function getLeftFromWord(word, cat) {
+  const indexWord = cat.indexOf(word);
+  return cat.substring(0, indexWord).trim();
 }
 
 function GetBlankEntityIfIsCountry(entity, entities) {


### PR DESCRIPTION
- \b only works for Latin base characters, umlauts are considered a word end (via [StackOverflow](https://stackoverflow.com/questions/10590098/javascript-regexp-word-boundaries-unicode-characters)]
- no word separator needed before the an upper case month name abbreviation, I'd say, as long it ends with a word separator

Test case: 27. März 1856