### PR TITLE
Whatlinkshere: colon and anchor handling

### DIFF
--- a/src/features/what_links_here/what_links_here.js
+++ b/src/features/what_links_here/what_links_here.js
@@ -109,17 +109,23 @@ function getWhatLinksHereLink(limit) {
   const thisURL = window.location.href;
   let dLink = "";
   // Edit page
-  const searchParams = new URLSearchParams(window.location.href);
+  const searchParams = new URLSearchParams(window.location.search);
   if ($("body.page-Special_EditPerson").length) {
     dLink = "Wiki:" + window.profileWTID;
   } else if (searchParams.has("title")) {
-    dLink = "Wiki:" + searchParams.get("title");
+    const title = decodeURIComponent(searchParams.get("title"));
+    if (title.includes(":")) {
+      dLink = title;
+    } else {
+      dLink = "Wiki:" + title;
+    }
   } else if (thisURL.split(/\/wiki\//)[1]) {
     dLink = thisURL.split(/\/wiki\//)[1];
     if (!decodeURIComponent(dLink).match(/.+:.+/)) {
       dLink = "Wiki:" + dLink;
     }
   }
+  alert("dLink" + dLink);
   if (dLink != "") {
     return `/index.php?title=Special:Whatlinkshere/${dLink}&limit=${limit}`;
   }

--- a/src/features/what_links_here/what_links_here.js
+++ b/src/features/what_links_here/what_links_here.js
@@ -120,12 +120,11 @@ function getWhatLinksHereLink(limit) {
       dLink = "Wiki:" + title;
     }
   } else if (thisURL.split(/\/wiki\//)[1]) {
-    dLink = thisURL.split(/\/wiki\//)[1];
+    dLink = thisURL.split(/\/wiki\//)[1].split("#")[0];
     if (!decodeURIComponent(dLink).match(/.+:.+/)) {
       dLink = "Wiki:" + dLink;
     }
   }
-  alert("dLink" + dLink);
   if (dLink != "") {
     return `/index.php?title=Special:Whatlinkshere/${dLink}&limit=${limit}`;
   }


### PR DESCRIPTION
Tested with
* https://www.wikitree.com/wiki/Space%3AStammtisch
* https://www.wikitree.com/index.php?title=Category:Germany&redirect=no
* https://www.wikitree.com/wiki/Category:Germany
* https://www.wikitree.com/index.php?title=Automated:Lang_Itmann%2C_West_Virginia&action=edit&redirect=no
* https://www.wikitree.com/index.php?title=Space:WikiTree_BEE
* https://www.wikitree.com/wiki/Space:WikiTree_BEE
* https://www.wikitree.com/wiki/Project:Germany

Please squash, since I have somehow named the wrong feature, sorry