### PR TITLE
please squash: Add Person: Remove newlines before bio and empty bullets

### DIFF
--- a/src/features/add_person/add_person.js
+++ b/src/features/add_person/add_person.js
@@ -365,7 +365,8 @@ function moveCategories() {
     }
   }
   if (top != "") {
-    ta.value = top.substring(1) + bottom;
+    bottom = bottom.replace(/^\n+/, "");
+    ta.value = top.substring(1) + "\n" + bottom;
     if (oldValue != ta.value) {
       document.getElementById("wpSummary").value = "Moving categories. ";
     }

--- a/src/features/add_person/add_person.js
+++ b/src/features/add_person/add_person.js
@@ -355,6 +355,9 @@ function moveCategories() {
   let bottom = "";
 
   for (let i = 0; i < parts.length; i++) {
+    if (parts[i].trim() == "*") {
+      continue;
+    }
     if (parts[i].indexOf("[[Category") > -1) {
       top += "\n" + parts[i].replace("* [[Category", "[[Category");
     } else {

--- a/src/features/what_links_here/what_links_here.js
+++ b/src/features/what_links_here/what_links_here.js
@@ -109,17 +109,23 @@ function getWhatLinksHereLink(limit) {
   const thisURL = window.location.href;
   let dLink = "";
   // Edit page
-  const searchParams = new URLSearchParams(window.location.href);
+  const searchParams = new URLSearchParams(window.location.search);
   if ($("body.page-Special_EditPerson").length) {
     dLink = "Wiki:" + window.profileWTID;
   } else if (searchParams.has("title")) {
-    dLink = "Wiki:" + searchParams.get("title");
+    const title = decodeURIComponent(searchParams.get("title"));
+    if (title.includes(":")) {
+      dLink = title;
+    } else {
+      dLink = "Wiki:" + title;
+    }
   } else if (thisURL.split(/\/wiki\//)[1]) {
     dLink = thisURL.split(/\/wiki\//)[1];
     if (!decodeURIComponent(dLink).match(/.+:.+/)) {
       dLink = "Wiki:" + dLink;
     }
   }
+  alert("dLink" + dLink);
   if (dLink != "") {
     return `/index.php?title=Special:Whatlinkshere/${dLink}&limit=${limit}`;
   }

--- a/src/features/what_links_here/what_links_here.js
+++ b/src/features/what_links_here/what_links_here.js
@@ -120,12 +120,11 @@ function getWhatLinksHereLink(limit) {
       dLink = "Wiki:" + title;
     }
   } else if (thisURL.split(/\/wiki\//)[1]) {
-    dLink = thisURL.split(/\/wiki\//)[1];
+    dLink = thisURL.split(/\/wiki\//)[1].split("#")[0];
     if (!decodeURIComponent(dLink).match(/.+:.+/)) {
       dLink = "Wiki:" + dLink;
     }
   }
-  alert("dLink" + dLink);
   if (dLink != "") {
     return `/index.php?title=Special:Whatlinkshere/${dLink}&limit=${limit}`;
   }


### PR DESCRIPTION
Sometimes the add profile leads to empty bullets. Those are removed from the entire profile now. I can't think of any problematic cases, but wanted to have a second opinion anyway.

This will also remove newlines before the bio.

The other changed file was already included with 8403671