### PR TITLE
draft-ish: DateFixer: cut off " in"

### DIFF
--- a/src/features/date_fixer/date_fixer.js
+++ b/src/features/date_fixer/date_fixer.js
@@ -256,6 +256,11 @@ function displayWarning(inputElement, message) {
 }
 
 function sanitizeInput(input) {
+  const indexBlankIn = input.indexOf(" in");
+  if (indexBlankIn > -1) {
+    //cutting of a location part
+    input = input.substr(0, indexBlankIn);
+  }
   return input
     .replaceAll(/\s+/g, " ") // Replace all occurrences of multiple spaces with a single space
     .replaceAll(/[!"#$%&'()~=]/g, "") // Remove all special characters

--- a/src/features/date_fixer/date_fixer.js
+++ b/src/features/date_fixer/date_fixer.js
@@ -256,28 +256,33 @@ function displayWarning(inputElement, message) {
 }
 
 function splitAndMoveLocationIfPresent(input, inputElement) {
-  const indexBlankIn = input.indexOf(" in ");
-  if (indexBlankIn > -1) {
-    //cutting of a location part
-    const location = input.substr(indexBlankIn + " in ".length).trim();
-    input = input.substr(0, indexBlankIn);
-    if (location.length > 0) {
-      switch (inputElement.attr("id")) {
-        case "mBirthDate": {
-          document.getElementById("mBirthLocation").value = location;
-          break;
+  const separators = [" in ", "\t"];
+  for (let i = 0; i < separators.length; i++) {
+    const indexBlankIn = input.indexOf(separators[i]);
+    if (indexBlankIn > -1) {
+      //cutting of a location part
+      const location = input.substr(indexBlankIn + separators[i].length).trim();
+      input = input.substr(0, indexBlankIn);
+      if (location.length > 0) {
+        switch (inputElement.attr("id")) {
+          case "mBirthDate": {
+            document.getElementById("mBirthLocation").value = location;
+            break;
+          }
+          case "mDeathDate": {
+            document.getElementById("mDeathLocation").value = location;
+            break;
+          }
+          case "mMarriageDate": {
+            document.getElementById("mMarriageLocation").value = location;
+            break;
+          }
         }
-        case "mDeathDate": {
-          document.getElementById("mDeathLocation").value = location;
-          break;
-        }
-        case "mMarriageDate": {
-          document.getElementById("mMarriageLocation").value = location;
-          break;
-        }
+        break;
       }
     }
   }
+
   return input;
 }
 

--- a/src/features/date_fixer/date_fixer.js
+++ b/src/features/date_fixer/date_fixer.js
@@ -255,12 +255,33 @@ function displayWarning(inputElement, message) {
   }, 7000); // Removes the warning after 7 seconds
 }
 
-function sanitizeInput(input) {
-  const indexBlankIn = input.indexOf(" in");
+function splitAndMoveLocationIfPresent(input, inputElement) {
+  const indexBlankIn = input.indexOf(" in ");
   if (indexBlankIn > -1) {
     //cutting of a location part
+    const location = input.substr(indexBlankIn + " in ".length).trim();
     input = input.substr(0, indexBlankIn);
+    if (location.length > 0) {
+      switch (inputElement.attr("id")) {
+        case "mBirthDate": {
+          document.getElementById("mBirthLocation").value = location;
+          break;
+        }
+        case "mDeathDate": {
+          document.getElementById("mDeathLocation").value = location;
+          break;
+        }
+        case "mMarriageDate": {
+          document.getElementById("mMarriageLocation").value = location;
+          break;
+        }
+      }
+    }
   }
+  return input;
+}
+
+function sanitizeInput(input) {
   return input
     .replaceAll(/\s+/g, " ") // Replace all occurrences of multiple spaces with a single space
     .replaceAll(/[!"#$%&'()~=]/g, "") // Remove all special characters
@@ -553,6 +574,10 @@ function fixDates() {
 
     $("#dateWarning").remove(); // Remove any existing warnings
     $("#dateClarificationModal").remove(); // Remove any existing date clarification modal
+
+    if (window.dateFixerOptions["splitLocations"] == true) {
+      input = splitAndMoveLocationIfPresent(input, inputElement);
+    }
 
     input = sanitizeInput(input);
     console.log("After sanitization:", input);

--- a/src/features/date_fixer/date_fixer_options.js
+++ b/src/features/date_fixer/date_fixer_options.js
@@ -47,5 +47,11 @@ registerFeature({
       ],
       defaultValue: false,
     },
+    {
+      id: "splitLocations",
+      type: OptionType.CHECKBOX,
+      label: "chop off locations after 'in' and put them in the corresponding location field",
+      defaultValue: true,
+    },
   ],
 });

--- a/src/features/date_fixer/date_fixer_options.js
+++ b/src/features/date_fixer/date_fixer_options.js
@@ -50,7 +50,7 @@ registerFeature({
     {
       id: "splitLocations",
       type: OptionType.CHECKBOX,
-      label: "chop off locations after 'in' and put them in the corresponding location field",
+      label: "chop off locations and put them in the corresponding location field",
       defaultValue: true,
     },
   ],


### PR DESCRIPTION
Being able to paste whole strings with "<date> in <location>" and remaining only with the date. Moving the part after in to the next location field would be even cooler, don't you think?