### PR TITLE
Access Key for Family Dropdown

### DIFF
--- a/src/features/access_keys/access_keys.js
+++ b/src/features/access_keys/access_keys.js
@@ -40,6 +40,7 @@ function addAccessKeys(options) {
     setAccessKeyIfOptionEnabled(options.Compare, "a.viewDiffButton", "c", options);
     setAccessKeyIfOptionEnabled(options.AutoBio, ".editToolbarMenu0 a[data-id='Auto Bio']", "b", options);
     setAccessKeyIfOptionEnabled(options.AddTemplate, ".editToolbarMenu0 a[data-id='Add any template']", "t", options);
+    setAccessKeyIfOptionEnabled(options.FamilyDropdown, "#familyDropdown", "y", options);
     setCopyButtonAccessKeyAndClickEvent(options.CopyID, "Copy ID", "i");
     setCopyButtonAccessKeyAndClickEvent(options.CopyUserID, "Copy UserID", "j");
     setCopyButtonAccessKeyAndClickEvent(options.CopyLink, "Copy Wiki Link", "l");

--- a/src/features/access_keys/access_keys_options.js
+++ b/src/features/access_keys/access_keys_options.js
@@ -212,6 +212,12 @@ registerFeature({
           label: "Add any template (Access key: t)",
           defaultValue: true,
         },
+        {
+          id: "FamilyDropdown",
+          type: OptionType.CHECKBOX,
+          label: "Open Family Dropdown (Access key: y; needs space to open drop-down)",
+          defaultValue: true,
+        },
       ],
     },
   ],

--- a/src/features/family_dropdown/family_dropdown.js
+++ b/src/features/family_dropdown/family_dropdown.js
@@ -218,6 +218,8 @@ async function doFamilyDropdown() {
     }
   }
 
+  $("#familyDropdown").prop("selectedIndex", 1);
+
   // Copy on change handler
   $("#familyDropdown").on("change", function () {
     copyfamilyDropdown();


### PR DESCRIPTION
Unfortunately, you still need to press space after triggering the access key, in order to actually open the select box.

Without selected index, the arrow keys won't let you select any entry.

Am open for different solutions and for making it a hidden feature, but it works sufficiently for me :)