### PR TITLE
hotfix for Readability Options

### DIFF
--- a/src/core/common.css
+++ b/src/core/common.css
@@ -164,7 +164,3 @@ form[name="a_form"] {
 ul.scissors li {
   margin-right: 0.5em;
 }
-
-.toggle.toggle-section {
-  display: none;
-}


### PR DESCRIPTION
This code was hiding the radio buttons for expanding/collapsing research notes and sources as implemented in the Readability Options feature. If this happens, RO may collapse the section, leaving the user with no way to expand it after the fact.

This issue was caused by a change in common.css as part of commit 5b4159bec3711cec123e19d1113a7a09426ecc35.