### PR TITLE
Fix edit toolbar menu spacing issue

### DIFF
--- a/src/core/editToolbar/editToolbar.css
+++ b/src/core/editToolbar/editToolbar.css
@@ -1,5 +1,5 @@
 #editToolbarExt {
-  display: inline-block!important;
+  display: inline-block !important;
   width: 100%;
 }
 
@@ -26,7 +26,7 @@
   display: none;
   position: absolute;
   top: -1px;
-  left: 161px;
+  left: 105px;
   width: 160px;
   list-style: none;
   padding: 1;
@@ -51,7 +51,7 @@
   display: none;
   position: absolute;
   top: -1px;
-  left: 161px;
+  left: 125px;
   width: 160px;
   list-style: none;
   padding: 1;


### PR DESCRIPTION
Changed the left positioning value of the level 1 and 2 edit toolbar menus to compensate for additional left margins added in the new WikiTree design.