### PR TITLE
access key for Discard Draft

### DIFF
--- a/src/features/access_keys/access_keys.js
+++ b/src/features/access_keys/access_keys.js
@@ -18,14 +18,7 @@ function addAccessKeys(options) {
     $("body").append("<a style='display:none;' id='G2Grecent' href='https://" + mainDomain + "/g2g/activity'></a>");
     setAccessKeyIfOptionEnabled(options.Preview, "#previewButton", "p", options);
     setAccessKeyIfOptionEnabled(options.G2G, "#G2Grecent", "g", options);
-    setAccessKeyIfOptionEnabled(
-      options.Edit,
-      "a[data-bs-title='Edit Person Profile'],a[data-bs-title='Edit Free-Space Profile'],input[value='Edit Scratch Pad']",
-      //removed this one, because it comes from the old design - no clue from which page it came from:
-      //a[title='Edit Profile and Family Relationships'],
-      "e",
-      options
-    );
+    setEditAndDiscardDraftAccessKeys(options);
     setAccessKeyIfOptionEnabled(
       options.Edit && isCategoryPage,
       "div.EDIT a[title='Edit the text on this category page']",
@@ -134,6 +127,21 @@ function setJumpNavAccessKeys(options) {
         }
       }
     }
+  }
+}
+
+function setEditAndDiscardDraftAccessKeys(options) {
+  const discardLink = $('a[href*="&dd="]');
+  if (options.DiscardDraft && discardLink.length) {
+    discardLink[0].accessKey = "e";
+    discardLink[0].style.backgroundColor = "#fcb815";
+  } else {
+    setAccessKeyIfOptionEnabled(
+      options.Edit,
+      "a[data-bs-title='Edit Person Profile'],a[data-bs-title='Edit Free-Space Profile'],input[value='Edit Scratch Pad']",
+      "e",
+      options
+    );
   }
 }
 

--- a/src/features/access_keys/access_keys_options.js
+++ b/src/features/access_keys/access_keys_options.js
@@ -145,6 +145,12 @@ registerFeature({
           defaultValue: true,
         },
         {
+          id: "DiscardDraft",
+          type: OptionType.CHECKBOX,
+          label: "Discard draft (Access key: e)",
+          defaultValue: false,
+        },
+        {
           id: "TreeApps",
           type: OptionType.CHECKBOX,
           label: "Open Tree Apps (Access key: t)",


### PR DESCRIPTION
This adds an access key for the discard draft link in the warning message, which is off by default. It uses "e", just like the edit shortcut. To prevent conflicts, it will not set the edit shortcut, if there's a discard draft link. It will also highlight the discard link:
![grafik](https://github.com/user-attachments/assets/a711c54f-5753-4c71-972f-4616699a37f1)
