### PR TITLE
Adding Watchlist Filter

### DIFF
--- a/src/content.js
+++ b/src/content.js
@@ -175,6 +175,8 @@ import "./features/image_page_options/image_page_options";
 
 import "./features/links_to_new_tabs/links_to_new_tabs";
 
+import "./features/watchlistFilter/watchlistFilter";
+
 //import "./features/family_status_sync/family_status_sync"; // Disabled for now
 
 import "./features/help/help";

--- a/src/features/register_feature_options.js
+++ b/src/features/register_feature_options.js
@@ -370,6 +370,17 @@ registerFeature({
   ],
 });
 
+registerFeature({
+  name: "Watchlist Filter",
+  id: "watchlistFilter",
+  description: "Adds filtering options to the Watchlist.",
+  category: "Other",
+  creators: [{ name: "Steve Harris", wikitreeid: "Harris-5439" }],
+  contributors: [],
+  defaultValue: false,
+  pages: [isSpecialWatchedList],
+});
+
 /*
  * debugging features for development only
  *

--- a/src/features/watchlistFilter/watchlistFilter.js
+++ b/src/features/watchlistFilter/watchlistFilter.js
@@ -1,0 +1,149 @@
+import { shouldInitializeFeature } from "../../core/options/options_storage";
+
+shouldInitializeFeature("watchlistFilter").then((result) => {
+    if (!result) return;
+
+    if (window.location.href.includes("do_s=1")) return;
+
+    const table = document.querySelector("table");
+    if (!table) return;
+
+    // If partial list (show all or next button visible), don't enable filters
+    const showAllLink = document.querySelector("a[href*='limit=20000']");
+    const nextButton = document.querySelector("a.btn.btn-secondary, a[href*='start=']");
+    if (showAllLink || nextButton) {
+        const notice = document.createElement("div");
+        notice.className = "my-2 m-auto text-center fs-6";
+        notice.innerHTML =
+            '👉 WBE Watchlist filters require all profiles to be loaded. Please use the ' +
+            (showAllLink
+                ? `<a href="${showAllLink.href}">show all</a> link`
+                : `"Show All" option`) +
+            " first.";
+        table.before(notice);
+        return; // bail, don't build filters yet
+    }
+
+    // --- Build filter bar ---
+    const filterPanel = document.createElement("div");
+    filterPanel.className =
+        "mb-2 p-2 border border-success rounded d-flex flex-wrap gap-4 align-items-center";
+    filterPanel.innerHTML = `
+    <div>
+      <strong>Management:</strong><br>
+      <label><input type="radio" name="mgmt" value="all" checked> All</label>
+      <label><input type="radio" name="mgmt" value="managed"> Managed</label>
+      <label><input type="radio" name="mgmt" value="nonmanaged"> Non-Managed</label>
+    </div>
+    <div>
+      <strong>Gender:</strong><br>
+      <label><input type="checkbox" value="male"> Male</label>
+      <label><input type="checkbox" value="female"> Female</label>
+      <label><input type="checkbox" value="nogender"> No Gender</label>
+    </div>
+    <div>
+      <strong>Content Rank:</strong><br>
+      <label><input type="checkbox" value="cr0_3"> 0–3</label>
+      <label><input type="checkbox" value="cr4_5"> 4–5</label>
+      <label><input type="checkbox" value="cr6_7"> 6–7</label>
+      <label><input type="checkbox" value="cr8_9"> 8–9</label>
+      <label><input type="checkbox" value="cr10"> 10</label>
+      <label><input type="checkbox" value="crNone"> No CR</label>
+    </div>
+  `;
+    table.before(filterPanel);
+
+    // --- Preprocess rows: tag them with classes ---
+    table.querySelectorAll("tr").forEach((row) => {
+        if (row.querySelector("th")) return; // skip header
+
+        row.classList.add("watchlist-row");
+
+        const isManaged = !!row.querySelector('a[href*="Help:Profile_Manager"]');
+        row.classList.add(isManaged ? "mgmt-managed" : "mgmt-nonmanaged");
+
+        const personCell = row.querySelector("td");
+        const genderClass = personCell ? personCell.className : "";
+        if (genderClass.includes("person--male")) {
+            row.classList.add("gender-male");
+        } else if (genderClass.includes("person--female")) {
+            row.classList.add("gender-female");
+        } else {
+            row.classList.add("gender-nogender");
+        }
+
+        const crBadge = row.querySelector(".cr-details");
+        if (crBadge) {
+            const match = crBadge.textContent.match(/CR:(\d+)/);
+            if (match) {
+                const val = parseInt(match[1], 10);
+                if (val <= 3) row.classList.add("cr0_3");
+                else if (val <= 5) row.classList.add("cr4_5");
+                else if (val <= 7) row.classList.add("cr6_7");
+                else if (val <= 9) row.classList.add("cr8_9");
+                else if (val === 10) row.classList.add("cr10");
+            }
+        } else {
+            row.classList.add("crNone");
+        }
+    });
+
+    // --- Style element for rules ---
+    const styleEl = document.createElement("style");
+    document.head.appendChild(styleEl);
+
+    function applyFilter() {
+        const mgmt = filterPanel.querySelector("input[name=mgmt]:checked").value;
+        const genders = Array.from(
+            filterPanel.querySelectorAll(
+                "input[value=male], input[value=female], input[value=nogender]"
+            )
+        )
+            .filter((cb) => cb.checked)
+            .map((cb) => `gender-${cb.value}`);
+        const crs = Array.from(filterPanel.querySelectorAll("input[value^=cr]"))
+            .filter((cb) => cb.checked)
+            .map((cb) => cb.value);
+
+        let mgmtSel =
+            mgmt === "managed"
+                ? ".mgmt-managed"
+                : mgmt === "nonmanaged"
+                    ? ".mgmt-nonmanaged"
+                    : ".mgmt-managed, .mgmt-nonmanaged";
+
+        let genderSel =
+            genders.length > 0
+                ? genders.map((g) => `.${g}`).join(", ")
+                : ".gender-male, .gender-female, .gender-nogender";
+
+        let crSel =
+            crs.length > 0
+                ? crs.map((c) => `.${c}`).join(", ")
+                : ".cr0_3, .cr4_5, .cr6_7, .cr8_9, .cr10, .crNone";
+
+        // Base: hide all rows
+        let css = ".watchlist-row { display: none; }";
+
+        // Combine selectors
+        const selectors = [];
+        mgmtSel.split(",").forEach((m) => {
+            genderSel.split(",").forEach((g) => {
+                crSel.split(",").forEach((c) => {
+                    selectors.push(`tr.watchlist-row${m.trim()}${g.trim()}${c.trim()}`);
+                });
+            });
+        });
+
+        css += selectors.join(", ") + " { display: table-row; }";
+        styleEl.textContent = css;
+    }
+
+    // Bind events
+    filterPanel.querySelectorAll("input").forEach((input) =>
+        input.addEventListener("change", applyFilter)
+    );
+
+    // Initial run
+    applyFilter();
+});


### PR DESCRIPTION
Add Watchlist filter with management, gender, and content rank options.

**Features**

- Management filter: toggle between All, Managed, or Non-Managed profiles.
- Gender filter: multi-select checkboxes (Male, Female, No Gender).
- Content Rank filter: multi-select checkboxes (0–3, 4–5, 6–7, 8–9, 10, or no CR).

Filters work in combination, so you can drill down (e.g., Managed Females with CR 0-3). Filters only become active when the full watchlist is displayed (limit=20000) to ensure complete results.