### PR TITLE
Improved: remove dates from link preview scissors

### DIFF
--- a/src/features/scissors/scissors.js
+++ b/src/features/scissors/scissors.js
@@ -25,6 +25,7 @@ import { copyToClipboard } from "../../core/clipboard.js";
 
 shouldInitializeFeature("scissors").then((result) => {
   if (result) {
+    fixYearsWhenCopyingProfileLinkFromPreview();
     import("./scissors.css");
 
     $(document).on("click", ".copy--buttons button", async function (e) {
@@ -46,6 +47,27 @@ shouldInitializeFeature("scissors").then((result) => {
   }
 });
 
+async function fixYearsWhenCopyingProfileLinkFromPreview() {
+  const options = await getFeatureOptions("scissors");
+  if (!options.removeDates) {
+  }
+
+  const observer = new MutationObserver((mutationsList, observerInstance) => {
+    const pagePreviewInner = document.getElementById("pagePreviewInner");
+
+    if (pagePreviewInner) {
+      const copyButtons = pagePreviewInner.getElementsByTagName("ul")[0];
+      if (copyButtons) {
+        removeDatesFromWikiButtons(copyButtons);
+      }
+    }
+  });
+
+  observer.observe(document.body || document.documentElement, {
+    childList: true,
+    subtree: true,
+  });
+}
 async function helpScissors() {
   const options = await getFeatureOptions("scissors");
   const displayOptions = {};
@@ -204,13 +226,24 @@ async function helpScissors() {
 
   attachScissorsEvent();
 }
+function removeDatesFromWikiButtons(elements) {
+  const $buttons = $(elements)
+    .find("button[aria-label='Copy Wiki Link']")
+    .addBack("button[aria-label='Copy Wiki Link']");
 
+  $buttons.each(function () {
+    const $this = $(this);
+    const originalText = $this.data("copy-text");
+
+    if (originalText) {
+      const dateless = originalText.replace(/\s\([^\s]*[0-9]{3,4}.*\)/, "");
+      $this.data("copy-text", dateless).attr("data-copy-text", dateless);
+    }
+  });
+}
 function modifyLinkButtons(options) {
   if ((isProfilePage || isProfileEdit) && options.removeDates) {
-    const dateless = $("button[aria-label='Copy Wiki Link']")
-      .data("copy-text")
-      .replace(/\s\([^\s]*[0-9]{3,4}.*\)/, ""); //year brackets might contain abt., two years or one, but never a blank
-    $("button[aria-label='Copy Wiki Link']").data("copy-text", dateless).attr("data-copy-text", dateless);
+    removeDatesFromWikiButtons("button[aria-label='Copy Wiki Link']");
   }
 
   if (isSpacePage || isSpaceEdit) {

--- a/src/features/scissors/scissors.js
+++ b/src/features/scissors/scissors.js
@@ -53,12 +53,31 @@ async function fixYearsWhenCopyingProfileLinkFromPreview() {
   }
 
   const observer = new MutationObserver((mutationsList, observerInstance) => {
-    const pagePreviewInner = document.getElementById("pagePreviewInner");
+    for (const mutation of mutationsList) {
+      if (mutation.addedNodes.length > 0) {
+        for (const node of mutation.addedNodes) {
+          if (node.id === "pagePreviewInner") {
+            handleFoundElement(node);
+            return;
+          }
 
-    if (pagePreviewInner) {
-      const copyButtons = pagePreviewInner.getElementsByTagName("ul")[0];
-      if (copyButtons) {
-        removeDatesFromWikiButtons(copyButtons);
+          if (node.querySelector) {
+            const nestedTarget = node.querySelector("#pagePreviewInner");
+            if (nestedTarget) {
+              handleFoundElement(nestedTarget);
+              return;
+            }
+          }
+        }
+      }
+    }
+
+    function handleFoundElement(pagePreviewInner) {
+      if (pagePreviewInner) {
+        const copyButtons = pagePreviewInner.getElementsByTagName("ul")[0];
+        if (copyButtons) {
+          removeDatesFromWikiButtons(copyButtons);
+        }
       }
     }
   });

--- a/src/features/scissors/scissors_options.js
+++ b/src/features/scissors/scissors_options.js
@@ -8,6 +8,7 @@ import {
   isCategoryPage,
   isCategoryEdit,
   isImagePage,
+  isMainDomain,
 } from "../../core/pageType";
 
 registerFeature({
@@ -23,16 +24,7 @@ registerFeature({
     { name: "Florian Straub", wikitreeid: "Straub-620" },
   ],
   defaultValue: true,
-  pages: [
-    isWikiPage,
-    isProfileEdit,
-    isSpaceEdit,
-    isProfileHistoryDetail,
-    isNetworkFeed,
-    isCategoryEdit,
-    isCategoryPage,
-    isImagePage,
-  ],
+  pages: [isMainDomain] /* needs to be everywhere for bracket removal in page previews*/,
   options: [
     {
       id: "sectionLinkOnProfiles",


### PR DESCRIPTION
works like a charm on profile pages, but not on NavHomePage etc.; 
maybe we can find a better place for it, where it's loaded all the time, also in G2G and on other pages, @shogenapps?